### PR TITLE
Fixed bad import

### DIFF
--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -4,7 +4,7 @@ namespace Bugsnag\BugsnagBundle\DependencyInjection;
 
 use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
 use Bugsnag\Client;
-use Bugsnag\Configuration;
+use Bugsnag\Configuration as Config;
 
 class ClientFactory
 {
@@ -117,7 +117,7 @@ class ClientFactory
     {
         $guzzle = Client::makeGuzzle($this->endpoint);
 
-        $client = new Client(new Configuration($this->key), $this->resolver, $guzzle);
+        $client = new Client(new Config($this->key), $this->resolver, $guzzle);
 
         if ($this->callbacks) {
             $client->registerDefaultCallbacks();


### PR DESCRIPTION
The import of `Bugsnag\Configuration` conflicts with the `Configuration` class in the `Bugsnag\BugsnagBundle\DependencyInjection` namespace. This can be easily solved by aliasing the import.

---

Closes #7.