### PR TITLE
Fixed console exception reporting

### DIFF
--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -4,6 +4,7 @@ namespace Bugsnag\BugsnagBundle\EventListener;
 
 use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
 use Bugsnag\Client;
+use Bugsnag\Report;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -104,6 +105,8 @@ class BugsnagListener
             ],
         ];
 
-        $this->client->notifyException($exception, $meta);
+        $this->client->notifyException($exception, function (Report $report) use ($meta) {
+            $report->setMetaData($meta);
+        });
     }
 }


### PR DESCRIPTION
The 2nd parameter to our `notifyException` function is a callable which gets executed by the pipeline upon reporting the error. We should set the metadata using the correct method on the report instance within this callback.

---

Closes #7.