### PR TITLE
Implement ability for users to register custom callbacks via service definition tags.

### DIFF
--- a/BugsnagBundle.php
+++ b/BugsnagBundle.php
@@ -2,6 +2,8 @@
 
 namespace Bugsnag\BugsnagBundle;
 
+use Bugsnag\BugsnagBundle\DependencyInjection\Compiler\CallbackRegisteringPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class BugsnagBundle extends Bundle
@@ -12,4 +14,13 @@ class BugsnagBundle extends Bundle
      * @return string
      */
     const VERSION = '1.0.0';
+
+    /**
+     * @inheritdoc
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new CallbackRegisteringPass());
+    }
 }

--- a/Callbacks/UserSettingCallback.php
+++ b/Callbacks/UserSettingCallback.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Bugsnag\BugsnagBundle\Callbacks;
+
+use Bugsnag\Report;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class UserSettingCallback
+{
+    /**
+     * The token resolver.
+     *
+     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|null
+     */
+    protected $tokens;
+
+    /**
+     * The auth checker.
+     *
+     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|null
+     */
+    protected $checker;
+
+    /**
+     * @var bool
+     */
+    protected $setUser;
+
+    /**
+     * @param null|\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface $tokens
+     * @param null|\Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $checker
+     * @param bool $setUser
+     */
+    public function __construct(
+        TokenStorageInterface $tokens = null,
+        AuthorizationCheckerInterface $checker = null,
+        $setUser = true
+    ) {
+        $this->tokens = $tokens;
+        $this->checker = $checker;
+        $this->setUser = $setUser;
+    }
+
+    /**
+     * @param \Bugsnag\Report $report
+     */
+    public function registerCallback(Report $report)
+    {
+        // If told to not set the user, or the security services were not passed in
+        // (not registered in the container), then exit early
+        if (! $this->setUser || is_null($this->tokens) || is_null($this->checker)) {
+            return;
+        }
+
+        $token = $this->tokens->getToken();
+
+        if (!$token || !$this->checker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+            return;
+        }
+
+        $user = $token->getUser();
+
+        if ($user instanceof UserInterface) {
+            $bugsnagUser = ['id' => $user->getUsername()];
+        } else {
+            $bugsnagUser = ['id' => (string) $user];
+        }
+
+        $report->setUser($bugsnagUser);
+    }
+}

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -140,6 +140,13 @@ class ClientFactory
     protected $filters;
 
     /**
+     * Custom callbacks to register on the client.
+     *
+     * @var callable[]
+     */
+    protected $customCallbacks = [];
+
+    /**
      * Create a new client factory instance.
      *
      * @param \Bugsnag\BugsnagBundle\Request\SymfonyResolver                                           $resolver
@@ -204,6 +211,26 @@ class ClientFactory
     }
 
     /**
+     * Add a custom callback to be registered on the client.
+     *
+     * @param callable|array $callable
+     */
+    public function addCallback($callable)
+    {
+        // If the parameter is not a callable (if the method name does not exist on the class for example),
+        // then throw an exception informing the user
+        if (! is_callable($callable)) {
+            throw new \RuntimeException(sprintf(
+                "Could not add Bugsnag callback. Class %s does not contain the \"%s\" method.",
+                get_class($callable[0]),
+                $callable[1]
+            ));
+        }
+
+        $this->customCallbacks[] = $callable;
+    }
+
+    /**
      * Make a new client instance.
      *
      * @return \Bugsnag\Client
@@ -246,6 +273,10 @@ class ClientFactory
 
         if ($this->filters) {
             $client->setFilters($this->filters);
+        }
+
+        foreach ($this->customCallbacks as $callable) {
+            $client->registerCallback($callable);
         }
 
         return $client;

--- a/DependencyInjection/Compiler/CallbackRegisteringPass.php
+++ b/DependencyInjection/Compiler/CallbackRegisteringPass.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Bugsnag\BugsnagBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CallbackRegisteringPass implements CompilerPassInterface
+{
+    const FACTORY_SERVICE_NAME = 'bugsnag.factory';
+    const TAG_NAME = 'bugsnag.callback';
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (! $container->has(self::FACTORY_SERVICE_NAME)) {
+            return;
+        }
+
+        // Get the Bugsnag factory service
+        $bugsnagFactory = $container->findDefinition(self::FACTORY_SERVICE_NAME);
+
+        // Get all services tagged as a callback
+        $callbackServices = $container->findTaggedServiceIds(self::TAG_NAME);
+
+        // Add each callback to the factory service via an addCallback call
+        foreach ($callbackServices as $id => $tags) {
+            foreach ($tags as $attributes) {
+                // Get the method name to call on the service from the tag definition,
+                // defaulting to registerCallback
+                $method = isset($attributes['method']) ? $attributes['method'] : 'registerCallback';
+                $bugsnagFactory->addMethodCall('addCallback', [[new Reference($id), $method]]);
+            }
+        }
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,12 +6,9 @@ services:
         class: '%bugsnag.factory%'
         arguments:
           - '@bugsnag.resolver'
-          - '@?security.token_storage'
-          - '@?security.authorization_checker'
           - '%bugsnag.api_key%'
           - '%bugsnag.endpoint%'
           - '%bugsnag.callbacks%'
-          - '%bugsnag.user%'
           - '%bugsnag.app_type%'
           - '%bugsnag.app_version%'
           - '%bugsnag.batch_sending%'
@@ -38,3 +35,12 @@ services:
             - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 256 }
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 128 }
             - { name: kernel.event_listener, event: console.exception, method: onConsoleException, priority: 128 }
+
+    bugsnag.callbacks.user_setting:
+        class: Bugsnag\BugsnagBundle\Callbacks\UserSettingCallback
+        arguments:
+            - '@?security.token_storage'
+            - '@?security.authorization_checker'
+            - '%bugsnag.user%'
+        tags:
+            - { name: 'bugsnag.callback' }

--- a/Tests/Callbacks/UserSettingCallbackTest.php
+++ b/Tests/Callbacks/UserSettingCallbackTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Bugsnag\BugsnagBundle\Tests\Callbacks;
+
+use Bugsnag\BugsnagBundle\Callbacks\UserSettingCallback;
+use Bugsnag\Report;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\User\User;
+
+class UserSettingCallbackTest extends TestCase
+{
+    public function testUserNotSetWhenDisabled()
+    {
+        $tokenStorageMock = $this->getMockBuilder(TokenStorageInterface::class)
+            ->getMock();
+
+        $authorizationChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)
+            ->getMock();
+
+        $reportMock = $this->getBugsnagReportMock();
+        $reportMock
+            ->expects($this->never())
+            ->method('setUser');
+
+        $callback = new UserSettingCallback($tokenStorageMock, $authorizationChecker, false);
+        $callback->registerCallback($reportMock);
+    }
+
+    public function testUserNotSetWhenServicesNotPassed()
+    {
+        $reportMock = $this->getBugsnagReportMock();
+        $reportMock
+            ->expects($this->never())
+            ->method('setUser');
+
+        $callback = new UserSettingCallback(null, null, true);
+        $callback->registerCallback($reportMock);
+    }
+
+    public function testUserIsSetWhenLoggedIn()
+    {
+        $user = new User('example', 'example');
+
+        $tokenMock = $this->getMockBuilder(TokenInterface::class)
+            ->getMock();
+
+        $tokenMock
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+
+        $tokenStorageMock = $this->getMockBuilder(TokenStorageInterface::class)
+            ->getMock();
+
+        $tokenStorageMock
+            ->expects($this->once())
+            ->method('getToken')
+            ->willReturn($tokenMock);
+
+        $authorizationChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)
+            ->getMock();
+
+        $authorizationChecker
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with('IS_AUTHENTICATED_REMEMBERED')
+            ->willReturn(true);
+
+        $reportMock = $this->getBugsnagReportMock();
+        $reportMock
+            ->expects($this->once())
+            ->method('setUser')
+            ->with([
+                'id' => $user->getUsername()
+            ]);
+
+        $callback = new UserSettingCallback($tokenStorageMock, $authorizationChecker, true);
+        $callback->registerCallback($reportMock);
+    }
+
+    private function getBugsnagReportMock()
+    {
+        return $this->getMockBuilder(Report::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/Tests/DependencyInjection/Compiler/CallbackRegisteringPassTest.php
+++ b/Tests/DependencyInjection/Compiler/CallbackRegisteringPassTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Bugsnag\BugsnagBundle\Tests\DependencyInjection\Compiler;
+
+use Bugsnag\BugsnagBundle\DependencyInjection\ClientFactory;
+use Bugsnag\BugsnagBundle\DependencyInjection\Compiler\CallbackRegisteringPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CallbackRegisteringPassTest extends TestCase
+{
+    public function testTaggedCallbacksAreAddedToFactoryServiceDefinition()
+    {
+        $containerBuilder = new ContainerBuilder();
+
+        $factory = new Definition(ClientFactory::class);
+        $containerBuilder->setDefinition(CallbackRegisteringPass::FACTORY_SERVICE_NAME, $factory);
+
+        $taggedCallbackOne = new Definition();
+        $taggedCallbackOne->addTag(CallbackRegisteringPass::TAG_NAME);
+        $containerBuilder->setDefinition('callback_1', $taggedCallbackOne);
+
+        $taggedCallbackTwo = new Definition();
+        $taggedCallbackTwo->addTag(CallbackRegisteringPass::TAG_NAME, ['method' => 'customMethod']);
+        $containerBuilder->setDefinition('callback_2', $taggedCallbackTwo);
+
+        $pass = new CallbackRegisteringPass();
+        $pass->process($containerBuilder);
+
+        $this->assertSame(2, count($factory->getMethodCalls()));
+        $this->assertSame('addCallback', $factory->getMethodCalls()[0][0]);
+        $this->assertEquals([new Reference('callback_1'), 'registerCallback'], $factory->getMethodCalls()[0][1][0]);
+        $this->assertSame('addCallback', $factory->getMethodCalls()[1][0]);
+        $this->assertEquals([new Reference('callback_2'), 'customMethod'], $factory->getMethodCalls()[1][1][0]);
+    }
+}

--- a/example/symfony27/app/config/services.yml
+++ b/example/symfony27/app/config/services.yml
@@ -4,6 +4,8 @@ parameters:
 #    parameter_name: value
 
 services:
-#    service_name:
-#        class: AppBundle\Directory\ClassName
-#        arguments: ["@another_service_name", "plain_value", "%parameter_name%"]
+
+    bugsnag_metadata_callback:
+        class: AppBundle\Bugsnag\MetadataCallback
+        tags:
+            - { name: 'bugsnag.callback' }

--- a/example/symfony27/src/AppBundle/Bugsnag/MetadataCallback.php
+++ b/example/symfony27/src/AppBundle/Bugsnag/MetadataCallback.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AppBundle\Bugsnag;
+
+use Bugsnag\Report;
+
+class MetadataCallback
+{
+    /**
+     * @param \Bugsnag\Report $report
+     */
+    public function registerCallback(Report $report)
+    {
+        $report->setMetaData([
+            'custom_data_1' => 'custom_value_1',
+            'custom_data_2' => 'custom_value_2',
+        ]);
+    }
+}

--- a/example/symfony28/app/config/services.yml
+++ b/example/symfony28/app/config/services.yml
@@ -4,6 +4,8 @@ parameters:
 #    parameter_name: value
 
 services:
-#    service_name:
-#        class: AppBundle\Directory\ClassName
-#        arguments: ["@another_service_name", "plain_value", "%parameter_name%"]
+
+    bugsnag_metadata_callback:
+        class: AppBundle\Bugsnag\MetadataCallback
+        tags:
+            - { name: 'bugsnag.callback' }

--- a/example/symfony28/src/AppBundle/Bugsnag/MetadataCallback.php
+++ b/example/symfony28/src/AppBundle/Bugsnag/MetadataCallback.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AppBundle\Bugsnag;
+
+use Bugsnag\Report;
+
+class MetadataCallback
+{
+    /**
+     * @param \Bugsnag\Report $report
+     */
+    public function registerCallback(Report $report)
+    {
+        $report->setMetaData([
+            'custom_data_1' => 'custom_value_1',
+            'custom_data_2' => 'custom_value_2',
+        ]);
+    }
+}

--- a/example/symfony31/app/config/services.yml
+++ b/example/symfony31/app/config/services.yml
@@ -4,6 +4,8 @@ parameters:
 #    parameter_name: value
 
 services:
-#    service_name:
-#        class: AppBundle\Directory\ClassName
-#        arguments: ["@another_service_name", "plain_value", "%parameter_name%"]
+
+    bugsnag_metadata_callback:
+        class: AppBundle\Bugsnag\MetadataCallback
+        tags:
+            - { name: 'bugsnag.callback' }

--- a/example/symfony31/src/AppBundle/Bugsnag/MetadataCallback.php
+++ b/example/symfony31/src/AppBundle/Bugsnag/MetadataCallback.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AppBundle\Bugsnag;
+
+use Bugsnag\Report;
+
+class MetadataCallback
+{
+    /**
+     * @param \Bugsnag\Report $report
+     */
+    public function registerCallback(Report $report)
+    {
+        $report->setMetaData([
+            'custom_data_1' => 'custom_value_1',
+            'custom_data_2' => 'custom_value_2',
+        ]);
+    }
+}


### PR DESCRIPTION
This is my attempt at resolving issue #35.

This PR enables custom callbacks to be registered to the Bugsnag `Client` object, by creating a service and tagging it with the `bugsnag.callback` name.

The service must implement a `registerCallback` method, which is used in the same way as the `registerCallback` method on the Bugsnag client. This method name is definable on a per-service basis, by setting the `method` attribute on the tag.

I have also re-factored the existing user setting code in `ClientFactory` to be a callback service included in the bundle.

I have made additions to the example apps in the repo to show an example callback service, but have not written any documentation for the new feature as they seem to [live separately](https://docs.bugsnag.com/platforms/php/other/customizing-error-reports/).

@PReimers - does this implementation solve your use case?