### PR TITLE
Fixed travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,33 @@
 language: php
 
-php:
-  - 5.5.9
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
-
 sudo: false
 
+matrix:
+  include:
+    - php: 5.5.9
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: hhvm-3.6
+      sudo: required
+      dist: trusty
+      group: edge
+    - php: hhvm-3.9
+      sudo: required
+      dist: trusty
+      group: edge
+    - php: hhvm-3.12
+      sudo: required
+      dist: trusty
+      group: edge
+
+before_install:
+  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'hhvm.jit = false' >> /etc/hhvm/php.ini ; fi
+
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source --prefer-lowest ; fi
+  - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source ; fi
 
 script:
   - make test


### PR DESCRIPTION
Mimics the bugsnag-silex travis config, and fixes the recently broken hhvm on the original config, caused by recent changes by facebook affecting HHVM on travis.