### PR TITLE
Symfony 4 register-callbacks

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -28,6 +28,7 @@ services:
     bugsnag:
         class: '%bugsnag.client%'
         factory: ['@bugsnag.factory', make]
+        public: true
 
     bugsnag.listener:
         class: '%bugsnag.listener%'

--- a/example/symfony40/README.md
+++ b/example/symfony40/README.md
@@ -17,9 +17,15 @@ This example shows how to integrate Bugsnag with Symfony 4.  Full instructions o
 
 There are two ways of configuring your Bugsnag client.
 
-1. Use environment variables.  In this example you can set the `BUGSNAG_API_KEY` environment variable to your api key.
+1. Set the configuration options in `config/packages/bugsnag.yaml`.  These values will automatically be loaded in when the application starts.
 
-2. All other configuration should be in the applications `.env` file:
+```yaml
+bugsnag:
+    api_key: YOUR_API_KEY_HERE
+    auto_notify: true
+```
+
+2. Use environment variables.  In this example you can set the `BUGSNAG_API_KEY` environment variable to your api key. This can also be set in the applications `.env` file:
 
 ```
 BUGSNAG_API_KEY=YOUR_API_KEY_HERE

--- a/example/symfony40/composer.json
+++ b/example/symfony40/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-iconv": "*",
-        "bugsnag/bugsnag-symfony": "dev-cawllec/symfony-4",
+        "bugsnag/bugsnag-symfony": "dev-symfony-4-fixes",
         "sensio/framework-extra-bundle": "^5.1",
         "symfony/console": "^4.0",
         "symfony/flex": "^1.0",

--- a/example/symfony40/config/packages/bugsnag.yaml
+++ b/example/symfony40/config/packages/bugsnag.yaml
@@ -1,3 +1,2 @@
 bugsnag:
-  api_key: 'YOUR_API_KEY_HERE'
-  auto_notify: true
+  api_key: 'YOUR_API_KEY'

--- a/example/symfony40/config/packages/bugsnag.yaml
+++ b/example/symfony40/config/packages/bugsnag.yaml
@@ -1,0 +1,3 @@
+bugsnag:
+  api_key: 'YOUR_API_KEY_HERE'
+  auto_notify: true

--- a/example/symfony40/config/services.yaml
+++ b/example/symfony40/config/services.yaml
@@ -10,8 +10,6 @@ services:
         public: false       # Allows optimizing the container by removing unused services; this also means
                             # fetching services directly from the container via $container->get() won't work.
                             # The best practice is to be explicit about your dependencies anyway.
-        bind: 
-            $bugsnag: '@bugsnag'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
@@ -24,7 +22,7 @@ services:
     App\Controller\:
         resource: '../src/Controller'
         tags: ['controller.service_arguments']
-        
+
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/example/symfony40/src/Controller/DefaultController.php
+++ b/example/symfony40/src/Controller/DefaultController.php
@@ -3,18 +3,12 @@
 namespace App\Controller;
 
 use RuntimeException;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class DefaultController extends AbstractController
+class DefaultController extends Controller
 {
-    protected $bugsnag;
-
-    public function __construct($bugsnag)
-    {
-        $this->bugsnag = $bugsnag;
-    }
 
     /**
      * @Route("/", name="homepage")
@@ -39,7 +33,7 @@ class DefaultController extends AbstractController
      */
     public function callback()
     {
-        $this->bugsnag->registerCallback(function ($report) {
+        $this->container->get('bugsnag')->registerCallback(function ($report) {
             $report->setMetaData([
                 'account' => [
                     'name' => 'Acme Co.',
@@ -56,7 +50,7 @@ class DefaultController extends AbstractController
      */
     public function notify()
     {
-        $this->bugsnag->notifyException(new RuntimeException("It didn't crash!"));
+        $this->container->get('bugsnag')->notifyException(new RuntimeException("It didn't crash!"));
 
         return new Response("It didn't crash, but check your Bugsnag dashboard for the manual notification");
     }
@@ -66,7 +60,7 @@ class DefaultController extends AbstractController
      */
     public function metadata()
     {
-        $this->bugsnag->notifyException(new RuntimeException("It didn't crash, with metadata!"), function ($report) {
+        $this->container->get('bugsnag')->notifyException(new RuntimeException("It didn't crash, with metadata!"), function ($report) {
             $report->setMetaData([
                 'diagnostics' => [
                     'error' => 'RuntimeException',
@@ -83,7 +77,7 @@ class DefaultController extends AbstractController
      */
     public function severity()
     {
-        $this->bugsnag->notifyException(new RuntimeException("It didn't crash, with severity!"), function ($report) {
+        $this->container->get('bugsnag')->notifyException(new RuntimeException("It didn't crash, with severity!"), function ($report) {
             $report->setSeverity('info');
         });
 

--- a/example/symfony40/src/Controller/DefaultController.php
+++ b/example/symfony40/src/Controller/DefaultController.php
@@ -9,7 +9,6 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class DefaultController extends Controller
 {
-
     /**
      * @Route("/", name="homepage")
      */

--- a/example/symfony40/src/Kernel.php
+++ b/example/symfony40/src/Kernel.php
@@ -14,6 +14,16 @@ class Kernel extends BaseKernel
 
     const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
+    public function boot()
+    {
+        parent::boot();
+        $this->container->get('bugsnag')->registerCallback(function($report) {
+            $report->setMetaData([
+                'account'=>'testAccount'
+            ]);
+        });
+    }
+
     public function getCacheDir()
     {
         return $this->getProjectDir().'/var/cache/'.$this->environment;

--- a/example/symfony40/src/Kernel.php
+++ b/example/symfony40/src/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Bugsnag\Report;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -17,9 +18,12 @@ class Kernel extends BaseKernel
     public function boot()
     {
         parent::boot();
-        $this->container->get('bugsnag')->registerCallback(function ($report) {
-            $report->setMetaData([
-                'account' => 'testAccount',
+        $this->container->get('bugsnag')->registerCallback(function (Report $report) {
+            $report->addMetaData([
+                'instance' => [
+                    'name' => 'TestServer',
+                    'ip' => '0.0.0.0'
+                ],
             ]);
         });
     }


### PR DESCRIPTION
Adds `public` property to `bugsnag` service to allow registration of callbacks in kernel, as well as example.