### PR TITLE
Check if session is started

### DIFF
--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -45,7 +45,7 @@ class SymfonyRequest implements RequestInterface
     {
         $session = $this->request->getSession();
 
-        return $session ? $session->all() : [];
+        return $session && $session->isStarted() ? $session->all() : [];
     }
 
     /**


### PR DESCRIPTION
## Goal

This fixes a behaviour when getting session was starting new session. If session was not started. $session->all() was starting a session for example adding a session cookie on exception pages.

### Added

`$session->isStarted()` check