### PR TITLE
Add config flag to suppress http errors

### DIFF
--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -273,7 +273,7 @@ class ClientFactory
                 return ($report->getName() == HttpException::class || is_subclass_of($report->getName(), HttpException::class))
                     ? false
                     : $report
-                    ;
+                ;
             });
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -83,6 +83,9 @@ class Configuration implements ConfigurationInterface
                     ->treatNullLike([])
                     ->defaultValue([])
                 ->end()
+                ->booleanNode('suppress_http_errors')
+                    ->defaultValue(false)
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -24,6 +24,7 @@ services:
           - '%bugsnag.release_stage%'
           - '%bugsnag.notify_release_stages%'
           - '%bugsnag.filters%'
+          - '%bugsnag.suppress_http_errors%'
 
     bugsnag:
         class: '%bugsnag.client%'


### PR DESCRIPTION
This bundle currently reports all http exceptions, even though they are caught and converted into 4xx-level pages by the symfony framework. See: https://github.com/bugsnag/bugsnag-symfony/issues/67

This PR adds a configuration parameter to disable reporting http errors. It defaults to false to preserve current behavior for BC reasons.