### PR TITLE
Fix root node for Symfony 4.2 and lower

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('bugsnag');
+        $treeBuilder = new TreeBuilder('bugsnag');
+        $rootNode = $this->getRootNode($treeBuilder, 'bugsnag');
 
         $rootNode
             ->children()
@@ -86,5 +86,15 @@ class Configuration implements ConfigurationInterface
             ->end();
 
         return $treeBuilder;
+    }
+
+    private function getRootNode(TreeBuilder $treeBuilder, $name)
+    {
+        // BC layer for symfony/config 4.1 and older
+        if ( ! \method_exists($treeBuilder, 'getRootNode')) {
+            return $treeBuilder->root($name);
+        }
+
+        return $treeBuilder->getRootNode();
     }
 }


### PR DESCRIPTION
## Goal

A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0. This Pull Request fix this and allow Symfony 4.2 users to use this bundle without deprecation notices.

### Changed

The way the Configuration is read.
