### PR TITLE
feat: add Symfony runtime version reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+*  Add Symfony version string to report and session payloads (device.runtimeVersions)
+  [#78](https://github.com/bugsnag/bugsnag-symfony/pull/78)
+
 ## 1.5.0 (2018-02-01)
 
 This release adds support for Symfony 4. A guide on integrating the notifier with a Symfony 4 application can be found in the [Bugsnag Symfony integration guide](https://docs.bugsnag.com/platforms/php/symfony/).

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -245,7 +245,7 @@ class ClientFactory
         $client->setHostname($this->hostname);
         $client->setSendCode($this->code);
 
-        $client->mergeDeviceData(['runtimeVersions' => ['symfony' => Kernel::VERSION]]);
+        $client->getConfig()->mergeDeviceData(['runtimeVersions' => ['symfony' => Kernel::VERSION]]);
 
         $client->setNotifier(array_filter([
             'name' => 'Bugsnag Symfony',

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -7,6 +7,7 @@ use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
 use Bugsnag\Callbacks\CustomUser;
 use Bugsnag\Client;
 use Bugsnag\Configuration as Config;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -243,6 +244,8 @@ class ClientFactory
         $client->setBatchSending($this->batch);
         $client->setHostname($this->hostname);
         $client->setSendCode($this->code);
+
+        $client->mergeDeviceData(['runtimeVersions' => ['symfony' => Kernel::VERSION]]);
 
         $client->setNotifier(array_filter([
             'name' => 'Bugsnag Symfony',

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/console": "^2.7|^3.0|^4.0",
         "symfony/http-foundation": "^2.7|^3.0|^4.0",
         "symfony/security": "^2.7|^3.0|^4.0",
-        "bugsnag/bugsnag": "^3.9"
+        "bugsnag/bugsnag": "^3.15.0"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",


### PR DESCRIPTION
Uses new hook in Configuration to append the Symfony application version to device data to
make it reportable.

## Goal

Augments reporting with the version of Symfony in use when an event occurred in case of issues in a specific version of the framework.

## Design

Added data to device.runtimeVersions.symfony as per other notifiers.

## Changeset

### Changed

* ClientFactory.make - appends the Symfony version from the HttpKernel class to the device data through the Bugsnag client

## Tests

* No unit tests present for this level of testing - checked the data was present after running the example symfony40 project

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
