### PR TITLE
Symfony 3.4 deprecation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Removed deprecation warnings on `Request.getSession` and `ConsoleEvents::EXCEPTION`
+  [Jan Myszkier](https://github.com/janmyszkier)
+  [#79](https://github.com/bugsnag/bugsnag-symfony/pull/79)
+
 ## 1.5.0 (2018-02-01)
 
 This release adds support for Symfony 4. A guide on integrating the notifier with a Symfony 4 application can be found in the [Bugsnag Symfony integration guide](https://docs.bugsnag.com/platforms/php/symfony/).

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -99,11 +99,10 @@ class Configuration implements ConfigurationInterface
      * Returns the root node of TreeBuilder with backwards compatibility
      * for pre-Symfony 4.1.
      *
-     * @param Symfony\Component\Config\Definition\Builder\TreeBuilder $treeBuilder a
-     *            TreeBuilder to extract/create the root node from
+     * @param TreeBuilder $treeBuilder a TreeBuilder to extract/create the root node
+     *                                 from
      *
-     * @return Symfony\Component\Config\Definition\Builder\NodeDefinition the root
-     *            node of the config
+     * @return NodeDefinition the root node of the config
      */
     protected function getRootNode(TreeBuilder $treeBuilder)
     {

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -93,7 +93,7 @@ class BugsnagListener implements EventSubscriberInterface
      */
     public function onConsoleException(ConsoleExceptionEvent $event)
     {
-        $meta = [ 'status' => $event->getExitCode() ];
+        $meta = ['status' => $event->getExitCode()];
         if ($event->getCommand()) {
             $meta['name'] = $event->getCommand()->getName();
         }
@@ -109,7 +109,7 @@ class BugsnagListener implements EventSubscriberInterface
      */
     public function onConsoleError(ConsoleErrorEvent $event)
     {
-        $meta = [ 'status' => $event->getExitCode() ];
+        $meta = ['status' => $event->getExitCode()];
         if ($event->getCommand()) {
             $meta['name'] = $event->getCommand()->getName();
         }
@@ -138,10 +138,11 @@ class BugsnagListener implements EventSubscriberInterface
         $this->client->notify($report);
     }
 
-    public static function getSubscribedEvents(){
+    public static function getSubscribedEvents()
+    {
         $listeners = [
             KernelEvents::REQUEST => ['onKernelRequest', 256],
-            KernelEvents::EXCEPTION => ['onKernelException', 128]
+            KernelEvents::EXCEPTION => ['onKernelException', 128],
         ];
 
         // Added ConsoleEvents in Symfony 2.3

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -84,7 +84,8 @@ class BugsnagListener implements EventSubscriberInterface
     }
 
     /**
-     * Handle a console exception.
+     * Handle a console exception (used instead of ConsoleErrorEvent before
+     * Symfony 3.3 and kept for backwards compatibility).
      *
      * @param \Symfony\Component\Console\Event\ConsoleExceptionEvent $event
      *

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -10,7 +10,11 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class BugsnagListener
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class BugsnagListener implements EventSubscriberInterface
 {
     /**
      * The bugsnag client instance.
@@ -133,5 +137,18 @@ class BugsnagListener
         $report->setMetaData($meta);
 
         $this->client->notify($report);
+    }
+
+    public static function getSubscribedEvents(){
+        $listeners = [
+            KernelEvents::REQUEST => ['onKernelRequest',256],
+            KernelEvents::EXCEPTION => ['onException',128]
+        ];
+
+        if (class_exists('Symfony\Component\Console\ConsoleEvents')) {
+            $listeners[class_exists('Symfony\Component\Console\Event\ConsoleErrorEvent') ? ConsoleEvents::ERROR : ConsoleEvents::EXCEPTION] = ['onConsoleException',128];
+        }
+
+        return $listeners;
     }
 }

--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -47,6 +47,7 @@ class SymfonyRequest implements RequestInterface
         if ($this->request->hasSession()) {
             $session = $this->request->getSession();
         }
+
         return $session ? $session->all() : [];
     }
 

--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -43,8 +43,10 @@ class SymfonyRequest implements RequestInterface
      */
     public function getSession()
     {
-        $session = $this->request->getSession();
-
+        $session = null;
+        if ($this->request->hasSession()) {
+            $session = $this->request->getSession();
+        }
         return $session ? $session->all() : [];
     }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -37,6 +37,4 @@ services:
           - '@bugsnag.resolver'
           - '%bugsnag.auto_notify%'
         tags:
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 256 }
-            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 128 }
-            - { name: kernel.event_listener, event: console.exception, method: onConsoleException, priority: 128 }
+          - { name: "kernel.event_subscriber" }

--- a/Tests/Listener/BugsnagListenerTest.php
+++ b/Tests/Listener/BugsnagListenerTest.php
@@ -6,11 +6,10 @@ use Bugsnag\BugsnagBundle\EventListener\BugsnagListener;
 use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
 use Bugsnag\Client;
 use Bugsnag\Report;
+use Exception;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use Mockery;
 use PHPUnit_Framework_TestCase as TestCase;
-
-use Exception;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;

--- a/Tests/Listener/BugsnagListenerTest.php
+++ b/Tests/Listener/BugsnagListenerTest.php
@@ -52,9 +52,6 @@ class BugsnagListenerTest extends TestCase
         $listener->onKernelException($event);
     }
 
-    /**
-     * @requires class foo
-     */
     public function testOnConsoleError()
     {
         if (!class_exists('Symfony\Component\Console\Event\ConsoleErrorEvent')) {

--- a/example/symfony40/README.md
+++ b/example/symfony40/README.md
@@ -78,3 +78,9 @@ To run the example:
 ```shell
 php bin/console server:run
 ```
+
+Or for the command example:
+
+```shell
+php bin/console app:crash
+```

--- a/example/symfony40/src/Command/CrashCommand.php
+++ b/example/symfony40/src/Command/CrashCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Command;
 
 use Exception;
@@ -14,7 +15,6 @@ class CrashCommand extends Command
     protected function configure()
     {
         $this->setDescription('Crashes for fun');
-
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/example/symfony40/src/Command/CrashCommand.php
+++ b/example/symfony40/src/Command/CrashCommand.php
@@ -1,0 +1,24 @@
+<?php
+namespace App\Command;
+
+use Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CrashCommand extends Command
+{
+    // the name of the command (the part after "bin/console")
+    protected static $defaultName = 'app:crash';
+
+    protected function configure()
+    {
+        $this->setDescription('Crashes for fun');
+
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        throw new Exception('Something bad happened!');
+    }
+}


### PR DESCRIPTION
## Goal

As per #74 but fixes a couple of issues (name of event `onKernelException` and `onConsoleError` takes `ConsoleErrorEvent`.

Also added fix for runtime deprecation warning caused by calling `Event.getSession` when session is null.

## Changeset

### Changed

* BugsnagListener/services.yml - amended to use new registration mechanism
* SymfonyRequest - guarded call to getSession

## Tests

* Ran examples on Symfony 2.7 and 4.0. 
* Added command example app.

### Linked issues

Fixes #75 

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
