### PR TITLE
Remove TreeBuilder.root deprecated usage

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,14 +11,21 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
+     * The name of the root of the configuration.
+     *
+     * @var string
+     */
+    const ROOT_NAME = 'bugsnag';
+
+    /**
      * Get the configuration tree builder.
      *
      * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('bugsnag');
-        $rootNode = $this->getRootNode($treeBuilder, 'bugsnag');
+        $treeBuilder = new TreeBuilder(self::ROOT_NAME);
+        $rootNode = $this->getRootNode($treeBuilder);
 
         $rootNode
             ->children()
@@ -88,13 +95,22 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    private function getRootNode(TreeBuilder $treeBuilder, $name)
+    /**
+     * Returns the root node of TreeBuilder with backwards compatibility
+     * for pre-Symfony 4.1.
+     *
+     * @param Symfony\Component\Config\Definition\Builder\TreeBuilder $treeBuilder a
+     *            TreeBuilder to extract/create the root node from
+     *
+     * @return Symfony\Component\Config\Definition\Builder\NodeDefinition the root
+     *            node of the config
+     */
+    protected function getRootNode(TreeBuilder $treeBuilder)
     {
-        // BC layer for symfony/config 4.1 and older
-        if ( ! \method_exists($treeBuilder, 'getRootNode')) {
-            return $treeBuilder->root($name);
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            return $treeBuilder->getRootNode();
+        } else {
+            return $treeBuilder->root(self::ROOT_NAME);
         }
-
-        return $treeBuilder->getRootNode();
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('bugsnag');
+        $treeBuilder = new TreeBuilder('bugsnag');
+        $rootNode = $this->getRootNode($treeBuilder, 'bugsnag');
 
         $rootNode
             ->children()
@@ -86,5 +86,15 @@ class Configuration implements ConfigurationInterface
             ->end();
 
         return $treeBuilder;
+    }
+
+    private function getRootNode(TreeBuilder $treeBuilder, $name)
+    {
+        // BC layer for symfony/config 4.1 and older
+        if ( ! \method_exists($treeBuilder, 'getRootNode')) {
+            return $treeBuilder->root($name);
+        }
+
+        return $treeBuilder->getRootNode();
     }
 }


### PR DESCRIPTION
## Goal

A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0. This Pull Request fix this and allow Symfony 4.2 users to use this bundle without deprecation notices.

## Changeset

### Changed

* Configuration.php - now returns the root node using `getRootNode` if on Symfony 4.1+

## Tests

* Manual regression of example projects

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
