### PR TITLE
Fixed deprecated since Symfony 4.1

### DIFF
--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -43,6 +43,10 @@ class SymfonyRequest implements RequestInterface
      */
     public function getSession()
     {
+        if (!$this->request->hasSession()) {
+            return [];
+        }
+
         $session = $this->request->getSession();
 
         return $session ? $session->all() : [];


### PR DESCRIPTION
Calling "Symfony\Component\HttpFoundation\Request::getSession()" when no session has been set is deprecated since Symfony 4.1 and will throw an exception in 5.0. Use "hasSession()" instead.