### PR TITLE
Fixed deprecated since Symfony 4.3

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,6 +18,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('bugsnag');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('bugsnag');
+        $treeBuilder = new TreeBuilder('bugsnag');
 
         $rootNode
             ->children()


### PR DESCRIPTION
Call TreeBuilder::root() deprecated since Symfony 4.3, pass the root name to the constructor instead
