### PR TITLE
Ensure trusty distro is set for travis where required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ sudo: false
 matrix:
   include:
     - php: 5.5.9
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
+      dist: trusty
     - php: 7.0
     - php: 7.1
     - php: hhvm-3.6


### PR DESCRIPTION
## Goal

Travis-ci now requires trusty distro to be specified for certain versions of PHP, as it is no longer the default.

This fixes the broken CI.