### PR TITLE
Add support for Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       dist: trusty
     - php: 7.0
     - php: 7.1
+    - php: 7.2
+    - php: 7.3
     - php: hhvm-3.6
       sudo: required
       dist: trusty

--- a/DependencyInjection/BugsnagExtension.php
+++ b/DependencyInjection/BugsnagExtension.php
@@ -28,5 +28,13 @@ class BugsnagExtension extends Extension
         foreach ($config as $key => $value) {
             $container->setParameter('bugsnag.'.$key, $value);
         }
+
+        if ($container->hasParameter('kernel.project_dir')) {
+            $symfonyRoot = $container->getParameter('kernel.project_dir');
+        } else {
+            $symfonyRoot = $container->getParameter('kernel.root_dir').'/../';
+        }
+
+        $container->setParameter('bugsnag.symfony_root', $symfonyRoot);
     }
 }

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -314,7 +314,7 @@ class ClientFactory
             return;
         }
 
-        $base = $root ? realpath("{$root}/../") : false;
+        $base = $root ? realpath("{$root}/") : false;
 
         if ($project) {
             if ($base && substr($project, 0, strlen($base)) === $base) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -5,6 +5,7 @@ namespace Bugsnag\BugsnagBundle\DependencyInjection;
 use Bugsnag\BugsnagBundle\EventListener\BugsnagListener;
 use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
 use Bugsnag\Client;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -19,7 +19,7 @@ services:
           - '%bugsnag.send_code%'
           - '%bugsnag.strip_path%'
           - '%bugsnag.project_root%'
-          - '%kernel.root_dir%'
+          - '%bugsnag.symfony_root%'
           - '%kernel.environment%'
           - '%bugsnag.release_stage%'
           - '%bugsnag.notify_release_stages%'

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/config": "^2.7|^3.0|^4.0",
-        "symfony/http-kernel": "^2.7|^3.0|^4.0",
-        "symfony/dependency-injection": "^2.7|^3.0|^4.0",
-        "symfony/console": "^2.7|^3.0|^4.0",
-        "symfony/http-foundation": "^2.7|^3.0|^4.0",
-        "symfony/security": "^2.7|^3.0|^4.0",
+        "symfony/config": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/http-kernel": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/dependency-injection": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/console": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/http-foundation": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/security-core": "^2.7|^3.0|^4.0|^5.0",
         "bugsnag/bugsnag": "^3.15.0"
     },
     "require-dev": {

--- a/example/symfony50/.env
+++ b/example/symfony50/.env
@@ -1,0 +1,21 @@
+# In all environments, the following files are loaded if they exist,
+# the latter taking precedence over the former:
+#
+#  * .env                contains default values for the environment variables needed by the app
+#  * .env.local          uncommitted file with local overrides
+#  * .env.$APP_ENV       committed environment-specific defaults
+#  * .env.$APP_ENV.local uncommitted environment-specific overrides
+#
+# Real environment variables win over .env files.
+#
+# DO NOT DEFINE PRODUCTION SECRETS IN THIS FILE NOR IN ANY OTHER COMMITTED FILES.
+#
+# Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
+# https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
+
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=ab155aecdc44c63659a93ab454370b2a
+#TRUSTED_PROXIES=127.0.0.1,127.0.0.2
+#TRUSTED_HOSTS='^localhost|example\.com$'
+###< symfony/framework-bundle ###

--- a/example/symfony50/.gitignore
+++ b/example/symfony50/.gitignore
@@ -1,0 +1,10 @@
+/composer.lock
+
+###> symfony/framework-bundle ###
+/.env.local
+/.env.local.php
+/.env.*.local
+/public/bundles/
+/var/
+/vendor/
+###< symfony/framework-bundle ###

--- a/example/symfony50/bin/console
+++ b/example/symfony50/bin/console
@@ -1,0 +1,42 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\ErrorHandler\Debug;
+
+if (false === in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+    echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;
+}
+
+set_time_limit(0);
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (!class_exists(Application::class)) {
+    throw new RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
+}
+
+$input = new ArgvInput();
+if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
+    putenv('APP_ENV='.$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
+}
+
+if ($input->hasParameterOption('--no-debug', true)) {
+    putenv('APP_DEBUG='.$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+}
+
+require dirname(__DIR__).'/config/bootstrap.php';
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+
+    if (class_exists(Debug::class)) {
+        Debug::enable();
+    }
+}
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$application = new Application($kernel);
+$application->run($input);

--- a/example/symfony50/composer.json
+++ b/example/symfony50/composer.json
@@ -1,0 +1,71 @@
+{
+    "type": "project",
+    "license": "proprietary",
+    "minimum-stability": "dev",
+    "require": {
+        "php": "^7.2.9",
+        "ext-ctype": "*",
+        "ext-iconv": "*",
+        "bugsnag/bugsnag-symfony": "^1.1",
+        "sensio/framework-extra-bundle": "^5.5@dev",
+        "symfony/console": "*",
+        "symfony/dotenv": "*",
+        "symfony/flex": "^1.3.1",
+        "symfony/framework-bundle": "*",
+        "symfony/yaml": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../bugsnag-symfony"
+        }
+    ],
+    "require-dev": {
+    },
+    "config": {
+        "preferred-install": {
+            "*": "dist"
+        },
+        "sort-packages": true
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\": "tests/"
+        }
+    },
+    "replace": {
+        "paragonie/random_compat": "2.*",
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-php72": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php56": "*"
+    },
+    "scripts": {
+        "auto-scripts": {
+            "cache:clear": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+        },
+        "post-install-cmd": [
+            "@auto-scripts"
+        ],
+        "post-update-cmd": [
+            "@auto-scripts"
+        ]
+    },
+    "conflict": {
+        "symfony/symfony": "*"
+    },
+    "extra": {
+        "symfony": {
+            "allow-contrib": false,
+            "require": "5.0.*"
+        }
+    }
+}

--- a/example/symfony50/config/bootstrap.php
+++ b/example/symfony50/config/bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+// Load cached env vars if the .env.local.php file exists
+// Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
+if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+    foreach ($env as $k => $v) {
+        $_ENV[$k] = $_ENV[$k] ?? (isset($_SERVER[$k]) && 0 !== strpos($k, 'HTTP_') ? $_SERVER[$k] : $v);
+    }
+} elseif (!class_exists(Dotenv::class)) {
+    throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+} else {
+    // load all the .env files
+    (new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
+}
+
+$_SERVER += $_ENV;
+$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
+$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/example/symfony50/config/bundles.php
+++ b/example/symfony50/config/bundles.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    Bugsnag\BugsnagBundle\BugsnagBundle::class => ['all' => true],
+    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
+];

--- a/example/symfony50/config/packages/bugsnag.yaml
+++ b/example/symfony50/config/packages/bugsnag.yaml
@@ -1,0 +1,2 @@
+bugsnag:
+  api_key: 'YOUR_API_KEY'

--- a/example/symfony50/config/packages/cache.yaml
+++ b/example/symfony50/config/packages/cache.yaml
@@ -1,0 +1,19 @@
+framework:
+    cache:
+        # Put the unique name of your app here: the prefix seed
+        # is used to compute stable namespaces for cache keys.
+        #prefix_seed: your_vendor_name/app_name
+
+        # The app cache caches to the filesystem by default.
+        # Other options include:
+
+        # Redis
+        #app: cache.adapter.redis
+        #default_redis_provider: redis://localhost
+
+        # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
+        #app: cache.adapter.apcu
+
+        # Namespaced pools use the above "app" backend by default
+        #pools:
+            #my.dedicated.cache: null

--- a/example/symfony50/config/packages/framework.yaml
+++ b/example/symfony50/config/packages/framework.yaml
@@ -1,0 +1,16 @@
+framework:
+    secret: '%env(APP_SECRET)%'
+    #csrf_protection: true
+    #http_method_override: true
+
+    # Enables session support. Note that the session will ONLY be started if you read or write from it.
+    # Remove or comment this section to explicitly disable session support.
+    session:
+        handler_id: null
+        cookie_secure: auto
+        cookie_samesite: lax
+
+    #esi: true
+    #fragments: true
+    php_errors:
+        log: true

--- a/example/symfony50/config/packages/prod/routing.yaml
+++ b/example/symfony50/config/packages/prod/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        strict_requirements: null

--- a/example/symfony50/config/packages/routing.yaml
+++ b/example/symfony50/config/packages/routing.yaml
@@ -1,0 +1,3 @@
+framework:
+    router:
+        utf8: true

--- a/example/symfony50/config/packages/sensio_framework_extra.yaml
+++ b/example/symfony50/config/packages/sensio_framework_extra.yaml
@@ -1,0 +1,3 @@
+sensio_framework_extra:
+    router:
+        annotations: false

--- a/example/symfony50/config/packages/test/framework.yaml
+++ b/example/symfony50/config/packages/test/framework.yaml
@@ -1,0 +1,4 @@
+framework:
+    test: true
+    session:
+        storage_id: session.storage.mock_file

--- a/example/symfony50/config/routes.yaml
+++ b/example/symfony50/config/routes.yaml
@@ -1,0 +1,3 @@
+index:
+    path: /
+    controller: App\Controller\DefaultController::index

--- a/example/symfony50/config/routes/annotations.yaml
+++ b/example/symfony50/config/routes/annotations.yaml
@@ -1,0 +1,3 @@
+controllers:
+    resource: ../../src/Controller/
+    type: annotation

--- a/example/symfony50/config/routes/dev/framework.yaml
+++ b/example/symfony50/config/routes/dev/framework.yaml
@@ -1,0 +1,3 @@
+_errors:
+    resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+    prefix: /_error

--- a/example/symfony50/config/secrets/prod/.gitignore
+++ b/example/symfony50/config/secrets/prod/.gitignore
@@ -1,0 +1,1 @@
+/prod.decrypt.private.php

--- a/example/symfony50/config/services.yaml
+++ b/example/symfony50/config/services.yaml
@@ -1,0 +1,27 @@
+# This file is the entry point to configure your own services.
+# Files in the packages/ subdirectory configure your dependencies.
+
+# Put parameters here that don't need to change on each machine where the app is deployed
+# https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
+parameters:
+
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    # makes classes in src/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    App\:
+        resource: '../src/*'
+        exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+
+    # controllers are imported separately to make sure services can be injected
+    # as action arguments even if you don't extend any base controller class
+    App\Controller\:
+        resource: '../src/Controller'
+        tags: ['controller.service_arguments']
+
+    # add more service definitions when explicit configuration is needed
+    # please note that last definitions always *replace* previous ones

--- a/example/symfony50/public/index.php
+++ b/example/symfony50/public/index.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Kernel;
+use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\HttpFoundation\Request;
+
+require dirname(__DIR__).'/config/bootstrap.php';
+
+if ($_SERVER['APP_DEBUG']) {
+    umask(0000);
+
+    Debug::enable();
+}
+
+if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
+    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
+}
+
+if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
+    Request::setTrustedHosts([$trustedHosts]);
+}
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$request = Request::createFromGlobals();
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);

--- a/example/symfony50/src/Controller/DefaultController.php
+++ b/example/symfony50/src/Controller/DefaultController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Controller;
+
+use Bugsnag\Report;
+use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class DefaultController extends AbstractController
+{
+    /**
+     * @Route("/", name="homepage")
+     */
+    public function index()
+    {
+        return new Response('Welcome to the Bugsnag Symfony 4 example. Visit the
+         file "src/Controller/DefaultController" to see how certain functions 
+        are implemented, and routes they can be tested on.');
+    }
+
+    /**
+     * @Route("/crash/", name="crash")
+     */
+    public function crash()
+    {
+        throw new RuntimeException('It crashed!  Go to your Bugsnag dashboard to view the exception');
+    }
+
+    /**
+     * @Route("/callback/", name="callback")
+     */
+    public function callback()
+    {
+        $this->container->get('bugsnag')->registerCallback(function (Report $report) {
+            $report->setMetaData([
+                'account' => [
+                    'name' => 'Acme Co.',
+                    'paying_customer' => true,
+                ],
+            ]);
+        });
+
+        throw new RuntimeException('It crashed!  Go to your Bugsnag dashboard to view the exception and metadata');
+    }
+
+    /**
+     * @Route("/notify/", name="notify")
+     */
+    public function notify()
+    {
+        $this->container->get('bugsnag')->notifyException(new RuntimeException("It didn't crash!"));
+
+        return new Response("It didn't crash, but check your Bugsnag dashboard for the manual notification");
+    }
+
+    /**
+     * @Route("/metadata/", name="metadata")
+     */
+    public function metadata()
+    {
+        $this->container->get('bugsnag')->notifyException(new RuntimeException("It didn't crash, with metadata!"), function (Report $report) {
+            $report->setMetaData([
+                'diagnostics' => [
+                    'error' => 'RuntimeException',
+                    'state' => 'Caught',
+                ],
+            ]);
+        });
+
+        return new Response("It didn't crash, but check your Bugsnag dashboard for the manual notification with additional metadata");
+    }
+
+    /**
+     * @Route("/severity/", name="severity")
+     */
+    public function severity()
+    {
+        $this->container->get('bugsnag')->notifyException(new RuntimeException("It didn't crash, with severity!"), function (Report $report) {
+            $report->setSeverity('info');
+        });
+
+        return new Response("It didn't crash, but check your Bugsnag dashboard for the manual notification, and check the severity of the report");
+    }
+}

--- a/example/symfony50/src/Kernel.php
+++ b/example/symfony50/src/Kernel.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
+
+    public function registerBundles(): iterable
+    {
+        $contents = require $this->getProjectDir().'/config/bundles.php';
+        foreach ($contents as $class => $envs) {
+            if ($envs[$this->environment] ?? $envs['all'] ?? false) {
+                yield new $class();
+            }
+        }
+    }
+
+    public function getProjectDir(): string
+    {
+        return \dirname(__DIR__);
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        $container->addResource(new FileResource($this->getProjectDir().'/config/bundles.php'));
+        $container->setParameter('container.dumper.inline_class_loader', true);
+        $confDir = $this->getProjectDir().'/config';
+
+        $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/{packages}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/{services}'.self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir.'/{services}_'.$this->environment.self::CONFIG_EXTS, 'glob');
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+        $confDir = $this->getProjectDir().'/config';
+
+        $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
+        $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
+    }
+}

--- a/example/symfony50/symfony.lock
+++ b/example/symfony50/symfony.lock
@@ -1,0 +1,164 @@
+{
+    "bugsnag/bugsnag-symfony": {
+        "version": "1.1-dev"
+    },
+    "doctrine/annotations": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "cb4152ebcadbe620ea2261da1a1c5a9b8cea7672"
+        },
+        "files": [
+            "config/routes/annotations.yaml"
+        ]
+    },
+    "doctrine/lexer": {
+        "version": "1.2.x-dev"
+    },
+    "psr/cache": {
+        "version": "1.0.x-dev"
+    },
+    "psr/container": {
+        "version": "1.0.x-dev"
+    },
+    "psr/event-dispatcher": {
+        "version": "1.0.x-dev"
+    },
+    "psr/log": {
+        "version": "1.1.x-dev"
+    },
+    "sensio/framework-extra-bundle": {
+        "version": "5.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "5.2",
+            "ref": "fb7e19da7f013d0d422fa9bce16f5c510e27609b"
+        },
+        "files": [
+            "config/packages/sensio_framework_extra.yaml"
+        ]
+    },
+    "symfony/cache": {
+        "version": "5.0-dev"
+    },
+    "symfony/cache-contracts": {
+        "version": "2.0-dev"
+    },
+    "symfony/config": {
+        "version": "5.0-dev"
+    },
+    "symfony/console": {
+        "version": "4.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.4",
+            "ref": "59d8cc5a923274e552412fcd51e284bba02982de"
+        },
+        "files": [
+            "bin/console",
+            "config/bootstrap.php"
+        ]
+    },
+    "symfony/dependency-injection": {
+        "version": "5.0-dev"
+    },
+    "symfony/dotenv": {
+        "version": "5.0-dev"
+    },
+    "symfony/error-handler": {
+        "version": "5.0-dev"
+    },
+    "symfony/event-dispatcher": {
+        "version": "5.0-dev"
+    },
+    "symfony/event-dispatcher-contracts": {
+        "version": "2.0-dev"
+    },
+    "symfony/filesystem": {
+        "version": "5.0-dev"
+    },
+    "symfony/finder": {
+        "version": "5.0-dev"
+    },
+    "symfony/flex": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "19fa03bacd9a6619583d1e4939da4388df22984d"
+        },
+        "files": [
+            ".env"
+        ]
+    },
+    "symfony/framework-bundle": {
+        "version": "4.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.4",
+            "ref": "9b91ef29da037baeec4c3715cf55bea2a165c902"
+        },
+        "files": [
+            "config/bootstrap.php",
+            "config/packages/cache.yaml",
+            "config/packages/framework.yaml",
+            "config/packages/test/framework.yaml",
+            "config/routes/dev/framework.yaml",
+            "config/secrets/prod/.gitignore",
+            "config/services.yaml",
+            "public/index.php",
+            "src/Controller/.gitignore",
+            "src/Kernel.php"
+        ]
+    },
+    "symfony/http-foundation": {
+        "version": "5.0-dev"
+    },
+    "symfony/http-kernel": {
+        "version": "5.0-dev"
+    },
+    "symfony/mime": {
+        "version": "5.0-dev"
+    },
+    "symfony/polyfill-intl-idn": {
+        "version": "1.12-dev"
+    },
+    "symfony/polyfill-mbstring": {
+        "version": "1.12-dev"
+    },
+    "symfony/polyfill-php73": {
+        "version": "1.12-dev"
+    },
+    "symfony/routing": {
+        "version": "4.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "4.2",
+            "ref": "683dcb08707ba8d41b7e34adb0344bfd68d248a7"
+        },
+        "files": [
+            "config/packages/prod/routing.yaml",
+            "config/packages/routing.yaml",
+            "config/routes.yaml"
+        ]
+    },
+    "symfony/service-contracts": {
+        "version": "2.0-dev"
+    },
+    "symfony/var-dumper": {
+        "version": "5.0-dev"
+    },
+    "symfony/var-exporter": {
+        "version": "5.0-dev"
+    },
+    "symfony/yaml": {
+        "version": "5.0-dev"
+    }
+}


### PR DESCRIPTION
Ref #91 

Two things were needed:
- bypass the removal of the `root_dir` parameter and use the `project_dir` if available (a new parameter `bugsnag.symfony_root` was added);
- add support for the new event classes.

I kept support for Symfony < 5 and Symfony >= 5.0 at the same time. I also added CI build for PHP 7.2 and PHP 7.3.

I also added an example application for Symfony 5.0.