### PR TITLE
Symfony 5 patch

### DIFF
--- a/BugsnagBundle.php
+++ b/BugsnagBundle.php
@@ -11,5 +11,5 @@ class BugsnagBundle extends Bundle
      *
      * @return string
      */
-    const VERSION = '1.6.0';
+    const VERSION = '1.6.1';
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## 1.6.1 (2020-01-06)
+
+### Fixes
+
+* Fix potential issue with ExceptionEvent missing getThrowable method in Symfony 4.3.
+  Additionally adds InvalidArgumentException in the case the event is triggered with an incorrect class.
+  [Loïck Piera](https://github.com/pyrech)
+  [#99](https://github.com/bugsnag/bugsnag-symfony/pull/99)
+
+
 ## 1.6.0 (2019-12-03)
 
 ### Enhancements

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -96,6 +96,8 @@ class BugsnagListener implements EventSubscriberInterface
             $this->sendNotify($event->getThrowable(), []);
         } elseif ($event instanceof GetResponseForExceptionEvent) {
             $this->sendNotify($event->getException(), []);
+        } else {
+            throw new InvalidArgumentException('onKernelException function only accepts GetResponseForExceptionEvent and ExceptionEvent arguments');
         }
     }
 

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -92,7 +92,7 @@ class BugsnagListener implements EventSubscriberInterface
         // The additional `method_exists` check is to prevent errors in Symfony 4.3
         // where the ExceptionEvent exists and is used but doesn't implement
         // the `getThrowable` method, which was introduced in Symfony 4.4
-        if ($event instanceof ExceptionEvent && method_exists($event, "getThrowable")) {
+        if ($event instanceof ExceptionEvent && method_exists($event, 'getThrowable')) {
             $this->sendNotify($event->getThrowable(), []);
         } elseif ($event instanceof GetResponseForExceptionEvent) {
             $this->sendNotify($event->getException(), []);

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -89,10 +89,13 @@ class BugsnagListener implements EventSubscriberInterface
     public function onKernelException($event)
     {
         // Compatibility with Symfony < 5 and Symfony >=5
-        if ($event instanceof GetResponseForExceptionEvent) {
-            $this->sendNotify($event->getException(), []);
-        } elseif ($event instanceof ExceptionEvent) {
+        // The additional `method_exists` check is to prevent errors in Symfony 4.3
+        // where the ExceptionEvent exists and is used but doesn't implement
+        // the `getThrowable` method, which was introduced in Symfony 4.4
+        if ($event instanceof ExceptionEvent && method_exists($event, "getThrowable")) {
             $this->sendNotify($event->getThrowable(), []);
+        } elseif ($event instanceof GetResponseForExceptionEvent) {
+            $this->sendNotify($event->getException(), []);
         }
     }
 

--- a/example/symfony27/web/config.php
+++ b/example/symfony27/web/config.php
@@ -69,55 +69,55 @@ $minorProblems = $symfonyRequirements->getFailedRecommendations();
                             You can also do the same by editing the ‘<strong>app/config/parameters.yml</strong>’ file directly.
                         </p>
 
-                        <?php if (count($majorProblems)): ?>
+                        <?php if (count($majorProblems)) { ?>
                             <h2 class="ko">Major problems</h2>
                             <p>Major problems have been detected and <strong>must</strong> be fixed before continuing:</p>
                             <ol>
-                                <?php foreach ($majorProblems as $problem): ?>
+                                <?php foreach ($majorProblems as $problem) { ?>
                                     <li><?php echo $problem->getTestMessage() ?>
                                         <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
                                     </li>
-                                <?php endforeach; ?>
+                                <?php } ?>
                             </ol>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if (count($minorProblems)): ?>
+                        <?php if (count($minorProblems)) { ?>
                             <h2>Recommendations</h2>
                             <p>
-                                <?php if (count($majorProblems)): ?>Additionally, to<?php else: ?>To<?php endif; ?> enhance your Symfony experience,
+                                <?php if (count($majorProblems)) { ?>Additionally, to<?php } else { ?>To<?php } ?> enhance your Symfony experience,
                                 it’s recommended that you fix the following:
                             </p>
                             <ol>
-                                <?php foreach ($minorProblems as $problem): ?>
+                                <?php foreach ($minorProblems as $problem) { ?>
                                     <li><?php echo $problem->getTestMessage() ?>
                                         <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
                                     </li>
-                                <?php endforeach; ?>
+                                <?php } ?>
                             </ol>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if ($symfonyRequirements->hasPhpIniConfigIssue()): ?>
+                        <?php if ($symfonyRequirements->hasPhpIniConfigIssue()) { ?>
                             <p id="phpini">*
-                                <?php if ($symfonyRequirements->getPhpIniConfigPath()): ?>
+                                <?php if ($symfonyRequirements->getPhpIniConfigPath()) { ?>
                                     Changes to the <strong>php.ini</strong> file must be done in "<strong><?php echo $symfonyRequirements->getPhpIniConfigPath() ?></strong>".
-                                <?php else: ?>
+                                <?php } else { ?>
                                     To change settings, create a "<strong>php.ini</strong>".
-                                <?php endif; ?>
+                                <?php } ?>
                             </p>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if (!count($majorProblems) && !count($minorProblems)): ?>
+                        <?php if (!count($majorProblems) && !count($minorProblems)) { ?>
                             <p class="ok">Your configuration looks good to run Symfony.</p>
-                        <?php endif; ?>
+                        <?php } ?>
 
                         <ul class="symfony-install-continue">
-                            <?php if (!count($majorProblems)): ?>
+                            <?php if (!count($majorProblems)) { ?>
                                 <li><a href="app_dev.php/_configurator/">Configure your Symfony Application online</a></li>
                                 <li><a href="app_dev.php/">Bypass configuration and go to the Welcome page</a></li>
-                            <?php endif; ?>
-                            <?php if (count($majorProblems) || count($minorProblems)): ?>
+                            <?php } ?>
+                            <?php if (count($majorProblems) || count($minorProblems)) { ?>
                                 <li><a href="config.php">Re-check configuration</a></li>
-                            <?php endif; ?>
+                            <?php } ?>
                         </ul>
                     </div>
                 </div>

--- a/example/symfony28/web/config.php
+++ b/example/symfony28/web/config.php
@@ -158,51 +158,51 @@ $minorProblems = $symfonyRequirements->getFailedRecommendations();
                             ready to run Symfony applications.
                         </p>
 
-                        <?php if (count($majorProblems)): ?>
+                        <?php if (count($majorProblems)) { ?>
                             <h2 class="ko">Major problems</h2>
                             <p>Major problems have been detected and <strong>must</strong> be fixed before continuing:</p>
                             <ol>
-                                <?php foreach ($majorProblems as $problem): ?>
+                                <?php foreach ($majorProblems as $problem) { ?>
                                     <li><?php echo $problem->getTestMessage() ?>
                                         <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
                                     </li>
-                                <?php endforeach; ?>
+                                <?php } ?>
                             </ol>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if (count($minorProblems)): ?>
+                        <?php if (count($minorProblems)) { ?>
                             <h2>Recommendations</h2>
                             <p>
-                                <?php if (count($majorProblems)): ?>Additionally, to<?php else: ?>To<?php endif; ?> enhance your Symfony experience,
+                                <?php if (count($majorProblems)) { ?>Additionally, to<?php } else { ?>To<?php } ?> enhance your Symfony experience,
                                 it’s recommended that you fix the following:
                             </p>
                             <ol>
-                                <?php foreach ($minorProblems as $problem): ?>
+                                <?php foreach ($minorProblems as $problem) { ?>
                                     <li><?php echo $problem->getTestMessage() ?>
                                         <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
                                     </li>
-                                <?php endforeach; ?>
+                                <?php } ?>
                             </ol>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if ($symfonyRequirements->hasPhpIniConfigIssue()): ?>
+                        <?php if ($symfonyRequirements->hasPhpIniConfigIssue()) { ?>
                             <p id="phpini">*
-                                <?php if ($symfonyRequirements->getPhpIniConfigPath()): ?>
+                                <?php if ($symfonyRequirements->getPhpIniConfigPath()) { ?>
                                     Changes to the <strong>php.ini</strong> file must be done in "<strong><?php echo $symfonyRequirements->getPhpIniConfigPath() ?></strong>".
-                                <?php else: ?>
+                                <?php } else { ?>
                                     To change settings, create a "<strong>php.ini</strong>".
-                                <?php endif; ?>
+                                <?php } ?>
                             </p>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if (!count($majorProblems) && !count($minorProblems)): ?>
+                        <?php if (!count($majorProblems) && !count($minorProblems)) { ?>
                             <p class="ok">All checks passed successfully. Your system is ready to run Symfony applications.</p>
-                        <?php endif; ?>
+                        <?php } ?>
 
                         <ul class="symfony-install-continue">
-                            <?php if (count($majorProblems) || count($minorProblems)): ?>
+                            <?php if (count($majorProblems) || count($minorProblems)) { ?>
                                 <li><a href="config.php">Re-check configuration</a></li>
-                            <?php endif; ?>
+                            <?php } ?>
                         </ul>
                     </div>
                 </div>

--- a/example/symfony31/web/config.php
+++ b/example/symfony31/web/config.php
@@ -158,51 +158,51 @@ $minorProblems = $symfonyRequirements->getFailedRecommendations();
                             ready to run Symfony applications.
                         </p>
 
-                        <?php if (count($majorProblems)): ?>
+                        <?php if (count($majorProblems)) { ?>
                             <h2 class="ko">Major problems</h2>
                             <p>Major problems have been detected and <strong>must</strong> be fixed before continuing:</p>
                             <ol>
-                                <?php foreach ($majorProblems as $problem): ?>
+                                <?php foreach ($majorProblems as $problem) { ?>
                                     <li><?php echo $problem->getTestMessage() ?>
                                         <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
                                     </li>
-                                <?php endforeach; ?>
+                                <?php } ?>
                             </ol>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if (count($minorProblems)): ?>
+                        <?php if (count($minorProblems)) { ?>
                             <h2>Recommendations</h2>
                             <p>
-                                <?php if (count($majorProblems)): ?>Additionally, to<?php else: ?>To<?php endif; ?> enhance your Symfony experience,
+                                <?php if (count($majorProblems)) { ?>Additionally, to<?php } else { ?>To<?php } ?> enhance your Symfony experience,
                                 it’s recommended that you fix the following:
                             </p>
                             <ol>
-                                <?php foreach ($minorProblems as $problem): ?>
+                                <?php foreach ($minorProblems as $problem) { ?>
                                     <li><?php echo $problem->getTestMessage() ?>
                                         <p class="help"><em><?php echo $problem->getHelpHtml() ?></em></p>
                                     </li>
-                                <?php endforeach; ?>
+                                <?php } ?>
                             </ol>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if ($symfonyRequirements->hasPhpIniConfigIssue()): ?>
+                        <?php if ($symfonyRequirements->hasPhpIniConfigIssue()) { ?>
                             <p id="phpini">*
-                                <?php if ($symfonyRequirements->getPhpIniConfigPath()): ?>
+                                <?php if ($symfonyRequirements->getPhpIniConfigPath()) { ?>
                                     Changes to the <strong>php.ini</strong> file must be done in "<strong><?php echo $symfonyRequirements->getPhpIniConfigPath() ?></strong>".
-                                <?php else: ?>
+                                <?php } else { ?>
                                     To change settings, create a "<strong>php.ini</strong>".
-                                <?php endif; ?>
+                                <?php } ?>
                             </p>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if (!count($majorProblems) && !count($minorProblems)): ?>
+                        <?php if (!count($majorProblems) && !count($minorProblems)) { ?>
                             <p class="ok">All checks passed successfully. Your system is ready to run Symfony applications.</p>
-                        <?php endif; ?>
+                        <?php } ?>
 
                         <ul class="symfony-install-continue">
-                            <?php if (count($majorProblems) || count($minorProblems)): ?>
+                            <?php if (count($majorProblems) || count($minorProblems)) { ?>
                                 <li><a href="config.php">Re-check configuration</a></li>
-                            <?php endif; ?>
+                            <?php } ?>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Goal

- To remove deprecation warnings from Symfony 4.4.
- To ensure continuity of responses/exceptions with previous interface.

## Changes

The order that the  `GetResponseForExceptionEvent` and `ExceptionEvent` are checked have been swapped.  This is because for within Symfony 4.3 & 4.4, `ExceptionEvent` is an extension of `GetResponseForExceptionEvent` and therefore would trigger either condition.  By ensuring `ExceptionEvent` comes first, we ensure the correct (non-deprecated) method, `getThrowable` is called when available.

However, within Symfony 4.3, event though the `ExceptionEvent` exists, neither it nor its base class, `GetResponseForExceptionEvent`, implement the `getThrowable` method.  This is why the `method_exists` check is present, to avoid attempting to call this method.

In addition, to ensure continuity with the `InvalidArgumentException` that would be thrown by adding type hints, this method will throw an `InvalidArgumentException` if the input is neither an `ExceptionEvent` with the `getThrowable` method, or a `GetResponseForExceptionEvent`.

## Tests

Unit testing the changes proves to be difficult for a number of reasons.

1. There is seemingly no easy way to ensure a test only runs against a specific version of Symfony

2. In Symfony 5 the `ExceptionEvent` class is marked as final, meaning it cannot be mocked via `mockery`.  It may be possible to create an `ExceptionEvent`, but because that requires an `HttpKernel` object it may be difficult to ensure all of the elements are in place and mockable to create a working configuration.

It would be feasible to create maze runner e2e tests in order to verify the change, however this would be a significant addition and may take time.