### PR TITLE
PHP 7.4 support and more rigorous testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,81 @@
 language: php
 
-sudo: false
-
 matrix:
   include:
     - php: 5.5.9
       dist: trusty
+      env: SYMFONY_VERSION=2.7.*
     - php: 5.5
       dist: trusty
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.5
+      dist: trusty
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.5
+      dist: trusty
+      env: SYMFONY_VERSION=^3.0
     - php: 5.6
       dist: trusty
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      dist: xenial
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.6
+      dist: xenial
+      env: SYMFONY_VERSION=^3.0
     - php: 7.0
+      dist: xenial
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.0
+      dist: xenial
+      env: SYMFONY_VERSION=^3.0
     - php: 7.1
+      dist: bionic
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.1
+      dist: bionic
+      env: SYMFONY_VERSION=^3.0
+    - php: 7.1
+      dist: bionic
+      env: SYMFONY_VERSION=^4.0
     - php: 7.2
+      dist: bionic
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7.2
+      dist: bionic
+      env: SYMFONY_VERSION=^3.0
+    - php: 7.2
+      dist: bionic
+      env: SYMFONY_VERSION=^4.0
+    - php: 7.2
+      dist: bionic
+      env: SYMFONY_VERSION=^5.0
     - php: 7.3
-    - php: hhvm-3.6
-      sudo: required
-      dist: trusty
-      group: edge
-    - php: hhvm-3.9
-      sudo: required
-      dist: trusty
-      group: edge
-    - php: hhvm-3.12
-      sudo: required
-      dist: trusty
-      group: edge
+      dist: bionic
+      env: SYMFONY_VERSION=^3.0
+    - php: 7.3
+      dist: bionic
+      env: SYMFONY_VERSION=^4.0
+    - php: 7.3
+      dist: bionic
+      env: SYMFONY_VERSION=^5.0
+    - php: 7.4
+      dist: bionic
+      env: SYMFONY_VERSION=^3.0
+    - php: 7.3
+      dist: bionic
+      env: SYMFONY_VERSION=^4.0
+    - php: 7.4
+      dist: bionic
+      env: SYMFONY_VERSION=^5.0
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then echo 'hhvm.jit = false' >> /etc/hhvm/php.ini ; fi
+  - travis_retry composer require "symfony/config:${SYMFONY_VERSION}" --no-update
+  - travis_retry composer require "symfony/console:${SYMFONY_VERSION}" --no-update
+  - travis_retry composer require "symfony/dependency-injection:${SYMFONY_VERSION}" --no-update
+  - travis_retry composer require "symfony/http-foundation:${SYMFONY_VERSION}" --no-update
+  - travis_retry composer require "symfony/http-kernel:${SYMFONY_VERSION}" --no-update
+  - travis_retry composer require "symfony/security-core:${SYMFONY_VERSION}" --no-update
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -13,18 +13,18 @@
     ],
     "require": {
         "php": ">=5.5",
+        "bugsnag/bugsnag": "^3.19",
         "symfony/config": "^2.7|^3|^4|^5",
-        "symfony/http-kernel": "^2.7|^3|^4|^5",
-        "symfony/dependency-injection": "^2.7|^3|^4|^5",
         "symfony/console": "^2.7|^3|^4|^5",
+        "symfony/dependency-injection": "^2.7|^3|^4|^5",
         "symfony/http-foundation": "^2.7|^3|^4|^5",
-        "symfony/security-core": "^2.7|^3|^4|^5",
-        "bugsnag/bugsnag": "^3.19"
+        "symfony/http-kernel": "^2.7|^3|^4|^5",
+        "symfony/security-core": "^2.7|^3|^4|^5"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",
-        "mockery/mockery": "^0.9.4",
-        "phpunit/phpunit": "^4.8|^5"
+        "mockery/mockery": "^0.9.4|^1.3.1",
+        "phpunit/phpunit": "^4.8.36|^5.6.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.19",
+        "bugsnag/bugsnag": "^3.20",
         "symfony/config": "^2.7|^3|^4|^5",
         "symfony/console": "^2.7|^3|^4|^5",
         "symfony/dependency-injection": "^2.7|^3|^4|^5",


### PR DESCRIPTION
This PR provides travis changes needed in order to enable https://github.com/bugsnag/bugsnag-symfony/pull/89. We're gonna need to conditionally require the messages component, to test newer symfony versions. This PR also drops HHVM in line with the main PHP notifier dropping it.