### PR TITLE
Allow setting project root and strip path as regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add new options for using regexes to match the project root and strip path
+  [#109](https://github.com/bugsnag/bugsnag-symfony/pull/109)
+
 ## 1.6.2 (2020-02-26)
 
 ### Bug Fixes

--- a/DependencyInjection/BugsnagExtension.php
+++ b/DependencyInjection/BugsnagExtension.php
@@ -12,8 +12,8 @@ class BugsnagExtension extends Extension
     /**
      * Loads a specific configuration.
      *
-     * @param array                                                   $configs
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param array $configs
+     * @param ContainerBuilder $container
      *
      * @return void
      */
@@ -21,18 +21,23 @@ class BugsnagExtension extends Extension
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../Resources/config')
+        );
 
         $loader->load('services.yml');
 
         foreach ($config as $key => $value) {
-            $container->setParameter('bugsnag.'.$key, $value);
+            $container->setParameter("bugsnag.{$key}", $value);
         }
 
         if ($container->hasParameter('kernel.project_dir')) {
             $symfonyRoot = $container->getParameter('kernel.project_dir');
         } else {
-            $symfonyRoot = $container->getParameter('kernel.root_dir').'/../';
+            $symfonyRoot = realpath(
+                $container->getParameter('kernel.root_dir') . '/../'
+            );
         }
 
         $container->setParameter('bugsnag.symfony_root', $symfonyRoot);

--- a/DependencyInjection/BugsnagExtension.php
+++ b/DependencyInjection/BugsnagExtension.php
@@ -12,7 +12,7 @@ class BugsnagExtension extends Extension
     /**
      * Loads a specific configuration.
      *
-     * @param array $configs
+     * @param array            $configs
      * @param ContainerBuilder $container
      *
      * @return void
@@ -23,7 +23,7 @@ class BugsnagExtension extends Extension
 
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__ . '/../Resources/config')
+            new FileLocator(__DIR__.'/../Resources/config')
         );
 
         $loader->load('services.yml');
@@ -36,7 +36,7 @@ class BugsnagExtension extends Extension
             $symfonyRoot = $container->getParameter('kernel.project_dir');
         } else {
             $symfonyRoot = realpath(
-                $container->getParameter('kernel.root_dir') . '/../'
+                $container->getParameter('kernel.root_dir').'/../'
             );
         }
 

--- a/DependencyInjection/BugsnagExtension.php
+++ b/DependencyInjection/BugsnagExtension.php
@@ -36,7 +36,7 @@ class BugsnagExtension extends Extension
             $symfonyRoot = $container->getParameter('kernel.project_dir');
         } else {
             $symfonyRoot = realpath(
-                $container->getParameter('kernel.root_dir').'/../'
+                $container->getParameter('kernel.root_dir').'/..'
             );
         }
 

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -102,12 +102,16 @@ class ClientFactory
     /**
      * The strip path.
      *
+     * Note this won't be used if 'stripPathRegex' is also given.
+     *
      * @var string|null
      */
     protected $strip;
 
     /**
      * The project root.
+     *
+     * Note this won't be used if 'projectRootRegex' is also given.
      *
      * @var string|null
      */
@@ -154,28 +158,46 @@ class ClientFactory
     protected $shutdownStrategy;
 
     /**
-     * Create a new client factory instance.
+     * The strip path as a regular expression.
      *
-     * @param \Bugsnag\BugsnagBundle\Request\SymfonyResolver                                           $resolver
-     * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|null $tokens
-     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|null        $checker
-     * @param string|null                                                                              $key
-     * @param string|null                                                                              $endpoint
-     * @param bool                                                                                     $callbacks
-     * @param bool                                                                                     $user
-     * @param string|null                                                                              $type
-     * @param string|null                                                                              $version
-     * @param bool                                                                                     $batch
-     * @param string|null                                                                              $hostname
-     * @param bool                                                                                     $code
-     * @param string|null                                                                              $strip
-     * @param string|null                                                                              $project
-     * @param string|null                                                                              $root
-     * @param string|null                                                                              $env
-     * @param string|null                                                                              $stage
-     * @param string[]|null                                                                            $stages
-     * @param string[]|null                                                                            $filters
-     * @param \Bugsnag\Shutdown\ShutdownStrategyInterface                                              $shutdownStrategy
+     * This takes precedence over 'strip' if both are given.
+     *
+     * @var string|null
+     */
+    protected $stripPathRegex;
+
+    /**
+     * The project root as a regular expression.
+     *
+     * This takes precedence over 'project' if both are given.
+     *
+     * @var string|null
+     */
+    protected $projectRootRegex;
+
+    /**
+     * @param SymfonyResolver $resolver
+     * @param TokenStorageInterface|null $tokens
+     * @param AuthorizationCheckerInterface|null $checker
+     * @param string|null $key
+     * @param string|null $endpoint
+     * @param bool $callbacks
+     * @param bool $user
+     * @param string|null $type
+     * @param string|null $version
+     * @param bool $batch
+     * @param string|null $hostname
+     * @param bool $code
+     * @param string|null $strip
+     * @param string|null $project
+     * @param string|null $root
+     * @param string|null $env
+     * @param string|null $stage
+     * @param string[]|null $stages
+     * @param string[]|null $filters
+     * @param ShutdownStrategyInterface $shutdownStrategy
+     * @param string|null $stripPathRegex
+     * @param string|null $projectRootRegex
      *
      * @return void
      */
@@ -199,7 +221,9 @@ class ClientFactory
         $stage = null,
         array $stages = null,
         array $filters = null,
-        ShutdownStrategyInterface $shutdownStrategy = null
+        ShutdownStrategyInterface $shutdownStrategy = null,
+        $stripPathRegex = null,
+        $projectRootRegex = null
     ) {
         $this->resolver = $resolver;
         $this->tokens = $tokens;
@@ -221,6 +245,8 @@ class ClientFactory
         $this->stages = $stages;
         $this->filters = $filters;
         $this->shutdownStrategy = $shutdownStrategy;
+        $this->stripPathRegex = $stripPathRegex;
+        $this->projectRootRegex = $projectRootRegex;
     }
 
     /**
@@ -242,7 +268,7 @@ class ClientFactory
             $this->setupUserDetection($client, $this->tokens, $this->checker);
         }
 
-        $this->setupPaths($client, $this->strip, $this->project, $this->root);
+        $this->setupPaths($client);
 
         $client->setReleaseStage($this->stage ?: ($this->env === 'prod' ? 'production' : $this->env));
 
@@ -304,43 +330,26 @@ class ClientFactory
     /**
      * Setup the client paths.
      *
-     * @param \Bugsnag\Client $client
-     * @param string|null     $strip
-     * @param string|null     $project
-     * @param string|null     $root
+     * @param Client $client
      *
      * @return void
      */
-    protected function setupPaths(Client $client, $strip, $project, $root)
+    protected function setupPaths(Client $client)
     {
-        if ($strip) {
-            $client->setStripPath($strip);
-
-            if (!$project) {
-                $client->setProjectRoot("{$strip}/src");
-            }
-
-            return;
+        if ($this->projectRootRegex !== null) {
+            $client->setProjectRootRegex($this->projectRootRegex);
+        } elseif ($this->project !== null) {
+            $client->setProjectRoot($this->project);
+        } else {
+            $client->setProjectRoot("{$this->root}/src");
         }
 
-        $base = $root ? realpath("{$root}/") : false;
-
-        if ($project) {
-            if ($base && substr($project, 0, strlen($base)) === $base) {
-                $client->setStripPath($base);
-            }
-
-            $client->setProjectRoot($project);
-
-            return;
-        }
-
-        if ($base) {
-            $client->setStripPath($base);
-
-            if ($root = realpath("{$base}/src")) {
-                $client->setProjectRoot($root);
-            }
+        if ($this->stripPathRegex !== null) {
+            $client->setStripPathRegex($this->stripPathRegex);
+        } elseif ($this->strip !== null) {
+            $client->setStripPath($this->strip);
+        } else {
+            $client->setStripPath($this->root);
         }
     }
 }

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -341,7 +341,7 @@ class ClientFactory
         } elseif ($this->project !== null) {
             $client->setProjectRoot($this->project);
         } else {
-            $client->setProjectRoot("{$this->root}/src");
+            $client->setProjectRoot($this->root.DIRECTORY_SEPARATOR.'src');
         }
 
         if ($this->stripPathRegex !== null) {

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -176,28 +176,28 @@ class ClientFactory
     protected $projectRootRegex;
 
     /**
-     * @param SymfonyResolver $resolver
-     * @param TokenStorageInterface|null $tokens
+     * @param SymfonyResolver                    $resolver
+     * @param TokenStorageInterface|null         $tokens
      * @param AuthorizationCheckerInterface|null $checker
-     * @param string|null $key
-     * @param string|null $endpoint
-     * @param bool $callbacks
-     * @param bool $user
-     * @param string|null $type
-     * @param string|null $version
-     * @param bool $batch
-     * @param string|null $hostname
-     * @param bool $code
-     * @param string|null $strip
-     * @param string|null $project
-     * @param string|null $root
-     * @param string|null $env
-     * @param string|null $stage
-     * @param string[]|null $stages
-     * @param string[]|null $filters
-     * @param ShutdownStrategyInterface $shutdownStrategy
-     * @param string|null $stripPathRegex
-     * @param string|null $projectRootRegex
+     * @param string|null                        $key
+     * @param string|null                        $endpoint
+     * @param bool                               $callbacks
+     * @param bool                               $user
+     * @param string|null                        $type
+     * @param string|null                        $version
+     * @param bool                               $batch
+     * @param string|null                        $hostname
+     * @param bool                               $code
+     * @param string|null                        $strip
+     * @param string|null                        $project
+     * @param string|null                        $root
+     * @param string|null                        $env
+     * @param string|null                        $stage
+     * @param string[]|null                      $stages
+     * @param string[]|null                      $filters
+     * @param ShutdownStrategyInterface          $shutdownStrategy
+     * @param string|null                        $stripPathRegex
+     * @param string|null                        $projectRootRegex
      *
      * @return void
      */

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Get the configuration tree builder.
      *
-     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {
@@ -93,6 +93,13 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('shutdown')
                     ->defaultValue(BugsnagShutdown::class)
+                ->end()
+                ->scalarNode('strip_path_regex')
+                    ->defaultNull()
+                ->end()
+                ->scalarNode('project_root_regex')
+                    ->defaultNull()
+                ->end()
             ->end();
 
         return $treeBuilder;
@@ -111,8 +118,8 @@ class Configuration implements ConfigurationInterface
     {
         if (\method_exists($treeBuilder, 'getRootNode')) {
             return $treeBuilder->getRootNode();
-        } else {
-            return $treeBuilder->root(self::ROOT_NAME);
         }
+
+        return $treeBuilder->root(self::ROOT_NAME);
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,6 +25,8 @@ services:
           - '%bugsnag.notify_release_stages%'
           - '%bugsnag.filters%'
           - '@bugsnag.shutdown'
+          - '%bugsnag.strip_path_regex%'
+          - '%bugsnag.project_root_regex%'
 
     bugsnag:
         class: '%bugsnag.client%'

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -7,8 +7,8 @@ use Bugsnag\BugsnagBundle\EventListener\BugsnagShutdown;
 use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
 use Bugsnag\Client;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
-use PHPUnit_Framework_TestCase as TestCase;
 use Mockery;
+use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionClass;
 use ReflectionException;
 
@@ -72,8 +72,8 @@ final class ClientFactoryTest extends TestCase
      * @param string|null $stripPath
      * @param string|null $projectRootRegex
      * @param string|null $stripPathRegex
-     * @param string $expectedProjectRootRegex
-     * @param string $expectedStripPathRegex
+     * @param string      $expectedProjectRootRegex
+     * @param string      $expectedStripPathRegex
      *
      * @return void
      *
@@ -252,7 +252,7 @@ final class ClientFactoryTest extends TestCase
     }
 
     /**
-     * Creates a Client, using the default arguments merged with any overrides
+     * Creates a Client, using the default arguments merged with any overrides.
      *
      * For example, by default the API key will be 'null', but can be specified
      * by passing '["key" => "example-123"]' to this method
@@ -276,7 +276,7 @@ final class ClientFactoryTest extends TestCase
     }
 
     /**
-     * Get an array of default arguments for the ClientFactory
+     * Get an array of default arguments for the ClientFactory.
      *
      * This is an associative array purely to document the arguments — they are
      * applied in order rather than by name, i.e. index 0 will always be the

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -5,56 +5,290 @@ namespace Bugsnag\BugsnagBundle\Tests\DependencyInjection;
 use Bugsnag\BugsnagBundle\DependencyInjection\ClientFactory;
 use Bugsnag\BugsnagBundle\EventListener\BugsnagShutdown;
 use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
+use Bugsnag\Client;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use PHPUnit_Framework_TestCase as TestCase;
+use Mockery;
+use ReflectionClass;
+use ReflectionException;
 
-class ClientFactoryTest extends TestCase
+final class ClientFactoryTest extends TestCase
 {
     use MockeryTrait;
 
-    protected $factoryArgs;
+    private $rootPath = '/example/root/path';
 
-    public function setUp()
+    public function tearDown()
     {
-        parent::setUp();
-        $this->setDefaultArgs();
+        $this->tearDownMockery();
     }
 
     public function testShutdownStrategyIsPassedToClient()
     {
-        $shutdown = \Mockery::mock(BugsnagShutdown::class);
+        $shutdown = Mockery::mock(BugsnagShutdown::class);
         $shutdown->shouldReceive('registerShutdownStrategy')->once();
-        $this->factoryArgs['shutdownStrategy'] = $shutdown;
-        $factory = self::createFactory($this->factoryArgs);
-        $client = $factory->make();
+
+        $client = $this->createClient(['shutdown_strategy' => $shutdown]);
 
         $shutdown->shouldHaveReceived('registerShutdownStrategy', [$client]);
-        $this->tearDownMockery();
     }
 
     /**
-     * Creates a factory from arguments supplied as an associative array.
+     * Ensure the project root and strip path are both set with sensible defaults
+     * when no explicit configuration is provided.
      *
-     * @param $args
-     *
-     * @throws \ReflectionException
-     *
-     * @return ClientFactory
+     * @return void
      */
-    protected static function createFactory($args)
+    public function testProjectRootAndStripPathAreInferredWhenNoSpecificConfigurationIsGiven()
     {
-        $class = new \ReflectionClass(ClientFactory::class);
+        $client = $this->createClient(['root' => $this->rootPath]);
 
-        return $class->newInstanceArgs(array_values($args));
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $config = $client->getConfig();
+
+        $projectRootRegex = $this->getProperty($config, 'projectRootRegex');
+        $stripPathRegex = $this->getProperty($config, 'stripPathRegex');
+
+        $expectedProjectRootRegex = $this->pathToRegex("{$this->rootPath}/src");
+        $expectedStripPathRegex = $this->pathToRegex($this->rootPath);
+
+        $this->assertSame(
+            $expectedStripPathRegex,
+            $stripPathRegex,
+            "Expected to set a sensible default for the 'stripPathRegex'"
+        );
+
+        $this->assertSame(
+            $expectedProjectRootRegex,
+            $projectRootRegex,
+            "Expected to set a sensible default for the 'projectRootRegex'"
+        );
     }
 
     /**
-     * Sets an associative array of default variables that can be accessed/edited to configure different factories.
+     * @param string|null $projectRoot
+     * @param string|null $stripPath
+     * @param string|null $projectRootRegex
+     * @param string|null $stripPathRegex
+     * @param string $expectedProjectRootRegex
+     * @param string $expectedStripPathRegex
+     *
+     * @return void
+     *
+     * @dataProvider projectRootAndStripPathProvider
      */
-    protected function setDefaultArgs()
+    public function testProjectRootAndStripPathAreSetCorrectly(
+        $projectRoot,
+        $stripPath,
+        $projectRootRegex,
+        $stripPathRegex,
+        $expectedProjectRootRegex,
+        $expectedStripPathRegex
+    ) {
+        $client = $this->createClient([
+            'root' => $this->rootPath,
+            'project' => $projectRoot,
+            'strip' => $stripPath,
+            'project_root_regex' => $projectRootRegex,
+            'strip_path_regex' => $stripPathRegex,
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $config = $client->getConfig();
+
+        $projectRootRegex = $this->getProperty($config, 'projectRootRegex');
+        $stripPathRegex = $this->getProperty($config, 'stripPathRegex');
+
+        $this->assertSame(
+            $expectedProjectRootRegex,
+            $projectRootRegex,
+            "Expected the 'projectRootRegex' to match the string provided in configuration"
+        );
+
+        $this->assertSame(
+            $expectedStripPathRegex,
+            $stripPathRegex,
+            "Expected the 'stripPathRegex' to match the string provided in configuration"
+        );
+    }
+
+    public function projectRootAndStripPathProvider()
     {
-        $this->factoryArgs = [
-            'resolver' => \Mockery::mock(SymfonyResolver::class),
+        return [
+            // If both strings are provided, both options should be set to the
+            // regex version of the given strings
+            'both strings provided' => [
+                'project_root' => '/example/project/root',
+                'strip_path' => '/example/strip/path',
+                'project_root_regex' => null,
+                'strip_path_regex' => null,
+                'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
+                'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
+            ],
+
+            // If both regexes are provided they should be set verbatim
+            'both regexes provided' => [
+                'project_root' => null,
+                'strip_path' => null,
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
+            // If only the project root string is provided, the project root should
+            // be set to the regex version of the string and the strip path to
+            // the kernel project directory (the root of the project)
+            'only project root string provided' => [
+                'project_root' => '/example/project/root',
+                'strip_path' => null,
+                'project_root_regex' => null,
+                'strip_path_regex' => null,
+                'expected_project_root_regex' => $this->pathToRegex('/example/project/root'),
+                'expected_strip_path_regex' => $this->pathToRegex($this->rootPath),
+            ],
+
+            // If only the project root regex is provided, it should be set
+            // and the strip path should be set to the kernel project directory
+            'only project root regex provided' => [
+                'project_root' => null,
+                'strip_path' => null,
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => null,
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => $this->pathToRegex($this->rootPath),
+            ],
+
+            // If only the strip path string is provided, both values should be
+            // set — the stip path to the regex version of the string and the
+            // project root to the kernel project directory with "/src" appended
+            'only strip path string provided' => [
+                'project_root' => null,
+                'strip_path' => '/example/strip/path',
+                'project_root_regex' => null,
+                'strip_path_regex' => null,
+                'expected_project_root_regex' => $this->pathToRegex("{$this->rootPath}/src"),
+                'expected_strip_path_regex' => $this->pathToRegex('/example/strip/path'),
+            ],
+
+            // If only the strip path regex is provided, the strip path should be
+            // set verbatim and the project root should be set to the kernel
+            // project directory
+            'only strip path regex provided' => [
+                'project_root' => null,
+                'strip_path' => null,
+                'project_root_regex' => null,
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => $this->pathToRegex("{$this->rootPath}/src"),
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
+            // If the regexes are provided and either string value is too then
+            // the regexes should take precedence and the string value ignored
+            'project root string and both regexes provided' => [
+                'project_root' => $this->pathToRegex('/example/project/root'),
+                'strip_path' => null,
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
+            // If the regexes are provided and either string value is too then
+            // the regexes should take precedence and the string value ignored
+            'strip path string and both regexes provided' => [
+                'project_root' => null,
+                'strip_path' => $this->pathToRegex('/example/strip/path'),
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+
+            // If all four options are provided then the regexes should take
+            // precedence and the string values ignored
+            'all options provided' => [
+                'project_root' => $this->pathToRegex('/example/project/root'),
+                'strip_path' => $this->pathToRegex('/example/strip/path'),
+                'project_root_regex' => '/^example project root regex/',
+                'strip_path_regex' => '/^example strip path regex/',
+                'expected_project_root_regex' => '/^example project root regex/',
+                'expected_strip_path_regex' => '/^example strip path regex/',
+            ],
+        ];
+    }
+
+    /**
+     * Get the value of the given property on the given object.
+     *
+     * @param object $object
+     * @param string $property
+     *
+     * @return mixed
+     */
+    private function getProperty($object, $property)
+    {
+        $propertyAccessor = function ($property) {
+            return $this->{$property};
+        };
+
+        return call_user_func($propertyAccessor->bindTo($object, $object), $property);
+    }
+
+    /**
+     * Convert a file path to a regex that matches the path and any sub paths.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    private function pathToRegex($path)
+    {
+        return sprintf('/^%s[\\/]?/i', preg_quote($path, '/'));
+    }
+
+    /**
+     * Creates a Client, using the default arguments merged with any overrides
+     *
+     * For example, by default the API key will be 'null', but can be specified
+     * by passing '["key" => "example-123"]' to this method
+     *
+     * @param array $argumentOverrides
+     *
+     * @throws ReflectionException
+     *
+     * @return Client
+     */
+    private function createClient(array $argumentOverrides = [])
+    {
+        $reflector = new ReflectionClass(ClientFactory::class);
+
+        $arguments = array_merge($this->defaultArguments(), $argumentOverrides);
+
+        /** @var ClientFactory $factory */
+        $factory = $reflector->newInstanceArgs($arguments);
+
+        return $factory->make();
+    }
+
+    /**
+     * Get an array of default arguments for the ClientFactory
+     *
+     * This is an associative array purely to document the arguments — they are
+     * applied in order rather than by name, i.e. index 0 will always be the
+     * first argument for ClientFactory, which won't necessarily be the
+     * '$resolver' if the parameter order changes
+     *
+     * @return array
+     */
+    private function defaultArguments()
+    {
+        return [
+            'resolver' => Mockery::mock(SymfonyResolver::class),
             'tokens' => null,
             'checker' => null,
             'key' => null,
@@ -68,12 +302,14 @@ class ClientFactoryTest extends TestCase
             'code' => true,
             'strip' => null,
             'project' => null,
-            'root' => null,
+            'root' => $this->rootPath,
             'env' => null,
             'stage' => null,
             'stages' => null,
             'filters' => null,
-            'shutdownStrategy' => null,
+            'shutdown_strategy' => null,
+            'strip_path_regex' => null,
+            'project_root_regex' => null,
         ];
     }
 }


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->

Recently we made a change to the Laravel notifier to expose the `setStripPathRegex` and `setProjectRootRegex` configuration options in the bugsnag-laravel config file — see https://github.com/bugsnag/bugsnag-laravel/pull/398

This PR adds the same configuration options to Symfony, which can be set like so:

```yml
bugsnag:
    strip_path_regex: '/^some regex$/'
    project_root_regex: '/^some other regex$/'
```

These options take precedence over the existing `strip_path` and `project_root` options. For example, if both `strip_path` and `strip_path_regex` are set, `strip_path_regex` will be used and `strip_path` will be ignored

<!-- For new features, include design documentation:

## Design

Why was this approach to the goal used?

-->


## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

The tests for this are mostly copied from the Laravel tests with the small change of using `src` rather than `app` for the default project root (which is used if neither project root configuration option is given)

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
