### PR TITLE
Run Symfony's latest release on CI

### DIFF
--- a/.ci/require-symfony.sh
+++ b/.ci/require-symfony.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+
+## Script to require a given Symfony version, e.g. "5.0"
+##
+## The version number is passed to composer as-is, so any syntax supported by
+## composer is also supported by this script (e.g. "^5", "5.*" etc...)
+##
+## This script also supports installing the latest version (including
+## pre-releases) by passing "latest" instead of a version number. This is done
+## using "lastversion", which will be installed with pip if needed
+## See https://github.com/dvershinin/lastversion
+
+set -e
+
+if [ $# -eq 0 ]; then
+    printf "Error: No Symfony version given\n\n"
+    printf "Usage:\n"
+    printf "  $ %s <version>\n\n" "$0"
+    printf "Examples:\n"
+    printf "  $ %s latest\n" "$0"
+    printf "  $ %s 5.0.0\n" "$0"
+    printf "  $ %s 4.3\n" "$0"
+
+    exit 64
+fi
+
+SYMFONY_VERSION=$1
+
+if [ "$SYMFONY_VERSION" = "latest" ]; then
+    if ! [ "$(command -v lastversion)" ]; then
+        # Install "lastversion" if it's not already installed
+        pip install lastversion==v1.1.5
+    fi
+
+    composer require "symfony/config:$(lastversion symfony/config --pre)" --no-update
+    composer require "symfony/console:$(lastversion symfony/console --pre)" --no-update
+    composer require "symfony/dependency-injection:$(lastversion symfony/dependency-injection --pre)" --no-update
+    composer require "symfony/http-foundation:$(lastversion symfony/http-foundation --pre)" --no-update
+    composer require "symfony/http-kernel:$(lastversion symfony/http-kernel --pre)" --no-update
+    composer require "symfony/security-core:$(lastversion symfony/security-core --pre)" --no-update
+else
+    # If we're requesting a specific version we can simply install it
+    composer require "symfony/config:${SYMFONY_VERSION}" --no-update
+    composer require "symfony/console:${SYMFONY_VERSION}" --no-update
+    composer require "symfony/dependency-injection:${SYMFONY_VERSION}" --no-update
+    composer require "symfony/http-foundation:${SYMFONY_VERSION}" --no-update
+    composer require "symfony/http-kernel:${SYMFONY_VERSION}" --no-update
+    composer require "symfony/security-core:${SYMFONY_VERSION}" --no-update
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,25 +77,10 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  # If we're requesting a specific version we can simply install it
-  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/config:${SYMFONY_VERSION}" --no-update ; fi
-  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/console:${SYMFONY_VERSION}" --no-update ; fi
-  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/dependency-injection:${SYMFONY_VERSION}" --no-update ; fi
-  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/http-foundation:${SYMFONY_VERSION}" --no-update ; fi
-  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/http-kernel:${SYMFONY_VERSION}" --no-update ; fi
-  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/security-core:${SYMFONY_VERSION}" --no-update ; fi
-  # If we want the latest version, install the "lastversion" script
-  # see https://github.com/dvershinin/lastversion
-  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry pip install lastversion==v1.1.5 ; fi
-  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/config:$(lastversion symfony/config --pre)" --no-update ; fi
-  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/console:$(lastversion symfony/console --pre)" --no-update ; fi
-  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/dependency-injection:$(lastversion symfony/dependency-injection --pre)" --no-update ; fi
-  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/http-foundation:$(lastversion symfony/http-foundation --pre)" --no-update ; fi
-  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/http-kernel:$(lastversion symfony/http-kernel --pre)" --no-update ; fi
-  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/security-core:$(lastversion symfony/security-core --pre)" --no-update ; fi
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
+  - ./.ci/require-symfony.sh "$SYMFONY_VERSION"
   - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist --prefer-lowest ; fi
   - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist ; fi
   # Show which versions of our direct dependencies we're using

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,10 @@ matrix:
       dist: bionic
       env: SYMFONY_VERSION=latest
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   # If we're requesting a specific version we can simply install it
   - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/config:${SYMFONY_VERSION}" --no-update ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ before_install:
   - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/security-core:${SYMFONY_VERSION}" --no-update ; fi
   # If we want the latest version, install the "lastversion" script
   # see https://github.com/dvershinin/lastversion
-  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry pip install lastversion ; fi
+  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry pip install lastversion==v1.1.5 ; fi
   - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/config:$(lastversion symfony/config --pre)" --no-update ; fi
   - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/console:$(lastversion symfony/console --pre)" --no-update ; fi
   - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/dependency-injection:$(lastversion symfony/dependency-injection --pre)" --no-update ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,8 +96,8 @@ before_install:
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
-  - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source --prefer-lowest ; fi
-  - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source ; fi
+  - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist --prefer-lowest ; fi
+  - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-dist ; fi
   # Show which versions of our direct dependencies we're using
   - composer show --direct
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,14 +68,29 @@ matrix:
     - php: 7.4
       dist: bionic
       env: SYMFONY_VERSION=^5.0
+    - php: 7.4
+      dist: bionic
+      env: SYMFONY_VERSION=latest
 
 before_install:
-  - travis_retry composer require "symfony/config:${SYMFONY_VERSION}" --no-update
-  - travis_retry composer require "symfony/console:${SYMFONY_VERSION}" --no-update
-  - travis_retry composer require "symfony/dependency-injection:${SYMFONY_VERSION}" --no-update
-  - travis_retry composer require "symfony/http-foundation:${SYMFONY_VERSION}" --no-update
-  - travis_retry composer require "symfony/http-kernel:${SYMFONY_VERSION}" --no-update
-  - travis_retry composer require "symfony/security-core:${SYMFONY_VERSION}" --no-update
+  # If we're requesting a specific version we can simply install it
+  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/config:${SYMFONY_VERSION}" --no-update ; fi
+  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/console:${SYMFONY_VERSION}" --no-update ; fi
+  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/dependency-injection:${SYMFONY_VERSION}" --no-update ; fi
+  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/http-foundation:${SYMFONY_VERSION}" --no-update ; fi
+  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/http-kernel:${SYMFONY_VERSION}" --no-update ; fi
+  - if [[ $SYMFONY_VERSION != "latest" ]]; then travis_retry composer require "symfony/security-core:${SYMFONY_VERSION}" --no-update ; fi
+  # If we want the latest version, install the "lastversion" script
+  # see https://github.com/dvershinin/lastversion
+  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry pip install lastversion ; fi
+  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/config:$(lastversion symfony/config --pre)" --no-update ; fi
+  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/console:$(lastversion symfony/console --pre)" --no-update ; fi
+  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/dependency-injection:$(lastversion symfony/dependency-injection --pre)" --no-update ; fi
+  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/http-foundation:$(lastversion symfony/http-foundation --pre)" --no-update ; fi
+  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/http-kernel:$(lastversion symfony/http-kernel --pre)" --no-update ; fi
+  - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/security-core:$(lastversion symfony/security-core --pre)" --no-update ; fi
+  # Show which versions of our direct dependencies we're using
+  - composer show --direct
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
     - php: 7.4
       dist: bionic
       env: SYMFONY_VERSION=^3.0
-    - php: 7.3
+    - php: 7.4
       dist: bionic
       env: SYMFONY_VERSION=^4.0
     - php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,13 +89,13 @@ before_install:
   - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/http-foundation:$(lastversion symfony/http-foundation --pre)" --no-update ; fi
   - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/http-kernel:$(lastversion symfony/http-kernel --pre)" --no-update ; fi
   - if [[ $SYMFONY_VERSION == "latest" ]]; then travis_retry composer require "symfony/security-core:$(lastversion symfony/security-core --pre)" --no-update ; fi
-  # Show which versions of our direct dependencies we're using
-  - composer show --direct
   - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
   - if [[ $TRAVIS_PHP_VERSION == 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source --prefer-lowest ; fi
   - if [[ $TRAVIS_PHP_VERSION != 5.5.9 ]]; then travis_retry composer update --no-interaction --prefer-source ; fi
+  # Show which versions of our direct dependencies we're using
+  - composer show --direct
 
 script:
   - make test


### PR DESCRIPTION
## Goal

This PR adds a job to Travis which will fetch the latest published version of Symfony rather than a pre-defined version, including pre-release versions. For example, right now the latest version is `v5.1.0-RC1`. This is done using [dvershinin/lastversion](https://github.com/dvershinin/lastversion)

We can now run `master` and `next` daily in order to alert us if an upcoming release will break this notifier

There are also a couple of changes in travis.yml that aren't totally related — we now cache Composer dependencies between runs to speed up builds, we run Symfony 4 on PHP 7.4 (a typo meant we didn't do this before) and I've [added a `composer show` step](https://travis-ci.com/github/bugsnag/bugsnag-symfony/jobs/337452474#L403) to print the exact version we're testing:

```
$ composer show --direct
bugsnag/bugsnag                v3.21.0    Official Bugsnag notifier for PHP...
graham-campbell/testbench-core v1.1.2     TestBench Core Provides Some Test...
mockery/mockery                1.3.1      Mockery is a simple yet flexible ...
phpunit/phpunit                5.7.27     The PHP Unit Testing framework.
symfony/config                 v5.1.0-RC1 Symfony Config Component
symfony/console                v5.1.0-RC1 Symfony Console Component
symfony/dependency-injection   v5.1.0-RC1 Symfony DependencyInjection Compo...
symfony/http-foundation        v5.1.0-RC1 Symfony HttpFoundation Component
symfony/http-kernel            v5.1.0-RC1 Symfony HttpKernel Component
symfony/security-core          v5.1.0-RC1 Symfony Security Component - Core...
```