### PR TITLE
Fix Symfony 'latest' CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
       dist: bionic
       env: SYMFONY_VERSION=^5.0
     - php: 7.4
-      dist: bionic
+      dist: focal
       env: SYMFONY_VERSION=latest
 
 cache:


### PR DESCRIPTION
## Goal

This fixes an issue caused by 'bionic' using Python 2.7 by default — the `lastversion` utility that we use to fetch the latest Symfony release from GitHub has updated and now requires Python 3

To fix this, we can simply switch the using the newer 'focal' dist which uses Python 3.6 by default