### PR TITLE
Allow PHPUnit 7 & 9 to be installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /composer.lock
 /composer.phar
 /.idea
+.phpunit.result.cache

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -8,7 +8,7 @@ use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
 use Bugsnag\Client;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use Mockery;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionException;
 
@@ -18,7 +18,10 @@ final class ClientFactoryTest extends TestCase
 
     private $rootPath = '/example/root/path';
 
-    public function tearDown()
+    /**
+     * @after
+     */
+    public function afterEach()
     {
         $this->tearDownMockery();
     }

--- a/Tests/Listener/BugsnagListenerTest.php
+++ b/Tests/Listener/BugsnagListenerTest.php
@@ -10,7 +10,7 @@ use Exception;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use InvalidArgumentException;
 use Mockery;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
@@ -52,11 +52,6 @@ class BugsnagListenerTest extends TestCase
         $listener->onKernelException($event);
     }
 
-    /**
-     * @requires PHP 5.6
-     *
-     * PHPUnit version installed with PHP 5.5 doesn't support TestCase::expectException
-     */
     public function testOnRequestArgumentException()
     {
         // Create mocks
@@ -64,8 +59,12 @@ class BugsnagListenerTest extends TestCase
         $event = Mockery::mock(GetResponseForExceptionEvent::class);
         $resolver = Mockery::mock(SymfonyResolver::class);
 
-        // Setup responses
-        $this->expectException(InvalidArgumentException::class);
+        // PHPUnit 4 doesn't have 'expectException'
+        if (method_exists(TestCase::class, 'expectException')) {
+            $this->expectException(InvalidArgumentException::class);
+        } else {
+            $this->setExpectedException(InvalidArgumentException::class);
+        }
 
         // Initiate test
         $listener = new BugsnagListener($client, $resolver, true);

--- a/Tests/Listener/BugsnagShutdownTest.php
+++ b/Tests/Listener/BugsnagShutdownTest.php
@@ -5,7 +5,7 @@ namespace Bugsnag\BugsnagBundle\Tests\Listener;
 use Bugsnag\BugsnagBundle\EventListener\BugsnagShutdown;
 use Bugsnag\Client;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\HttpKernel\KernelEvents;
 

--- a/Tests/Request/SymfonyRequestTest.php
+++ b/Tests/Request/SymfonyRequestTest.php
@@ -7,7 +7,7 @@ use Bugsnag\BugsnagBundle\Request\SymfonyResolver;
 use Bugsnag\Request\NullRequest;
 use Bugsnag\Request\RequestInterface;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 class SymfonyRequestTest extends TestCase

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",
         "mockery/mockery": "^0.9.4|^1.3.1",
-        "phpunit/phpunit": "^4.8.36|^5.6.3"
+        "phpunit/phpunit": "^4.8.36|^7.5.15|^9.3.10"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,12 +20,13 @@
             <directory suffix="Test.php">./Tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./Command</directory>
             <directory suffix=".php">./DependencyInjection</directory>
             <directory suffix=".php">./EventListener</directory>
             <directory suffix=".php">./Request</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
## Goal

This PR allows PHPUnit 7 & 9 to be installed where possible (gated by the PHP version). This allows us to start testing with PHP 8, as only PHPUnit 9 has compatibility

The actual changes are pretty minor:

- use the namespaced `TestCase` class as the PSR-0 version was removed
- use `@after` annotations rather than `tearDown` as we can't match the interface on PHP 5
- add compatibility for expected exception method name change between version 4 & 7/9 