### PR TITLE
Add PHP 8 to CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -60,6 +60,14 @@ jobs:
             symfony-version: '^5.0'
           - php-version: 7.4
             symfony-version: 'latest'
+          - php-version: 8.0
+            symfony-version: '^3.4'
+          - php-version: 8.0
+            symfony-version: '^4.4'
+          - php-version: 8.0
+            symfony-version: '^5.0'
+          - php-version: 8.0
+            symfony-version: 'latest'
 
     steps:
     - uses: actions/checkout@v2

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -31,7 +31,7 @@ final class ClientFactoryTest extends TestCase
         $shutdown = Mockery::mock(BugsnagShutdown::class);
         $shutdown->shouldReceive('registerShutdownStrategy')->once();
 
-        $client = $this->createClient(['shutdown_strategy' => $shutdown]);
+        $client = $this->createClient(['shutdownStrategy' => $shutdown]);
 
         $shutdown->shouldHaveReceived('registerShutdownStrategy', [$client]);
     }
@@ -94,8 +94,8 @@ final class ClientFactoryTest extends TestCase
             'root' => $this->rootPath,
             'project' => $projectRoot,
             'strip' => $stripPath,
-            'project_root_regex' => $projectRootRegex,
-            'strip_path_regex' => $stripPathRegex,
+            'projectRootRegex' => $projectRootRegex,
+            'stripPathRegex' => $stripPathRegex,
         ]);
 
         $this->assertInstanceOf(Client::class, $client);
@@ -281,10 +281,9 @@ final class ClientFactoryTest extends TestCase
     /**
      * Get an array of default arguments for the ClientFactory.
      *
-     * This is an associative array purely to document the arguments — they are
-     * applied in order rather than by name, i.e. index 0 will always be the
-     * first argument for ClientFactory, which won't necessarily be the
-     * '$resolver' if the parameter order changes
+     * Note: before PHP 8, this associative array only documents the arguments,
+     * i.e. they are applied in order rather than by name. PHP 8 will use these
+     * keys as named arguments to the ClientFactory constructor
      *
      * @return array
      */
@@ -310,9 +309,9 @@ final class ClientFactoryTest extends TestCase
             'stage' => null,
             'stages' => null,
             'filters' => null,
-            'shutdown_strategy' => null,
-            'strip_path_regex' => null,
-            'project_root_regex' => null,
+            'shutdownStrategy' => null,
+            'stripPathRegex' => null,
+            'projectRootRegex' => null,
         ];
     }
 }


### PR DESCRIPTION
## Goal

Add PHP 8 to CI for Symfony 3.4, 4.4, 5 and pre-release versions

This required a small change to tests as PHP 8 introduces named arguments, which we are inadvertently using by calling `ReflectionClass::newInstanceArgs`. This calls the constructor by unpacking the given argument array and if that array has string keys, it now uses them as named arguments. Our array keys didn't quite match the actual argument names, so this errored without the change

No actual code changes were required