### PR TITLE
Allow passing a Guzzle instance to Bugsnag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Allow passing a Guzzle instance to Bugsnag
+  [#117](https://github.com/bugsnag/bugsnag-symfony/pull/117)
+
 ## 1.7.0 (2020-06-01)
 
 ### Enhancements

--- a/DependencyInjection/BugsnagExtension.php
+++ b/DependencyInjection/BugsnagExtension.php
@@ -41,5 +41,11 @@ class BugsnagExtension extends Extension
         }
 
         $container->setParameter('bugsnag.symfony_root', $symfonyRoot);
+
+        // Register an alias for 'bugsnag.guzzle' if the user has supplied a
+        // service to use
+        if (isset($config['guzzle'])) {
+            $container->setAlias('bugsnag.guzzle', $config['guzzle']);
+        }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -100,6 +100,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('project_root_regex')
                     ->defaultNull()
                 ->end()
+                ->scalarNode('guzzle')
+                    ->defaultNull()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -27,6 +27,7 @@ services:
           - '@bugsnag.shutdown'
           - '%bugsnag.strip_path_regex%'
           - '%bugsnag.project_root_regex%'
+          - '@?bugsnag.guzzle'
 
     bugsnag:
         class: '%bugsnag.client%'

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -28,12 +28,27 @@ final class ClientFactoryTest extends TestCase
 
     public function testShutdownStrategyIsPassedToClient()
     {
+        /** @var \Mockery\MockInterface $shutdown */
         $shutdown = Mockery::mock(BugsnagShutdown::class);
         $shutdown->shouldReceive('registerShutdownStrategy')->once();
 
         $client = $this->createClient(['shutdownStrategy' => $shutdown]);
 
         $shutdown->shouldHaveReceived('registerShutdownStrategy', [$client]);
+    }
+
+    public function testGuzzleIsPassedToClient()
+    {
+        /** @var \Mockery\MockInterface $guzzle */
+        $guzzle = Mockery::mock(\GuzzleHttp\ClientInterface::class);
+        $guzzle->shouldIgnoreMissing();
+
+        $client = $this->createClient(['guzzle' => $guzzle]);
+
+        $httpClient = $this->getProperty($client, 'http');
+        $actual = $this->getProperty($httpClient, 'guzzle');
+
+        $this->assertSame($guzzle, $actual);
     }
 
     /**
@@ -312,6 +327,7 @@ final class ClientFactoryTest extends TestCase
             'shutdownStrategy' => null,
             'stripPathRegex' => null,
             'projectRootRegex' => null,
+            'guzzle' => null,
         ];
     }
 }


### PR DESCRIPTION
## Goal

This PR adds support for applications to pass a Guzzle instance to Bugsnag. This allows for configuring things like timeouts, proxy servers, add middleware etc...

We will read the service defined as `bugsnag.guzzle` if one exists, otherwise we create one internally as before. We also support passing the name of the service in Bugsnag configuration, so that users can pass a Guzzle instance that they already have configured

### How to use

Register a service that returns a Guzzle client, e.g.

```yml
custom_guzzle:
    class: GuzzleHttp\ClientInterface
    factory: ['App\GuzzleFactory', create]
```

Then tell Bugsnag about it:

```yml
bugsnag:
    api_key: YOUR_KEY_HERE
    guzzle: custom_guzzle
```

---

You can also register your service as 'bugsnag.guzzle' to avoid having to tell Bugsnag about it explicitly, e.g.

```yml
bugsnag.guzzle:
    class: GuzzleHttp\ClientInterface
    factory: ['App\GuzzleFactory', create]
```

Then you can omit 'guzzle' from Bugsnag's configuration:

```yml
bugsnag:
    api_key: YOUR_KEY_HERE
```

---

These examples use a factory, but any service definition that results in a `GuzzleHttp\ClientInterface` will work, for example:

```yml
custom_guzzle:
    class: GuzzleHttp\Client
    arguments:
        - { timeout: 5 }
```

## Testing

- Basic unit test added
- Tested manually on Symfony 2, 3, 4 & 5