### PR TITLE
Allow Bugsnag Symfony handle OOMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Out of memory errors will now be reported by increasing the memory limit by 5 MiB. Use the new `memoryLimitIncrease` configuration option to change the amount of memory, or set it to `null` to disable the increase entirely.
+  [#119](https://github.com/bugsnag/bugsnag-symfony/pull/119)
+
 ## 1.8.0 (2020-11-25)
 
 ### Enhancements

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -184,6 +184,15 @@ class ClientFactory
     private $guzzle;
 
     /**
+     * The amount to increase the memory_limit to handle an OOM.
+     *
+     * This can be disabled by setting "bugsnag.memory_limit_increase" to "null"
+     *
+     * @var int|null|false
+     */
+    private $memoryLimitIncrease;
+
+    /**
      * @param SymfonyResolver                    $resolver
      * @param TokenStorageInterface|null         $tokens
      * @param AuthorizationCheckerInterface|null $checker
@@ -207,6 +216,7 @@ class ClientFactory
      * @param string|null                        $stripPathRegex
      * @param string|null                        $projectRootRegex
      * @param GuzzleHttp\ClientInterface|null    $guzzle
+     * @param int|null|false                     $memoryLimitIncrease
      *
      * @return void
      */
@@ -233,7 +243,8 @@ class ClientFactory
         ShutdownStrategyInterface $shutdownStrategy = null,
         $stripPathRegex = null,
         $projectRootRegex = null,
-        GuzzleHttp\ClientInterface $guzzle = null
+        GuzzleHttp\ClientInterface $guzzle = null,
+        $memoryLimitIncrease = false
     ) {
         $this->resolver = $resolver;
         $this->tokens = $tokens;
@@ -260,6 +271,7 @@ class ClientFactory
         $this->guzzle = $guzzle === null
             ? Client::makeGuzzle()
             : $guzzle;
+        $this->memoryLimitIncrease = $memoryLimitIncrease;
     }
 
     /**
@@ -314,6 +326,11 @@ class ClientFactory
 
         if ($this->filters) {
             $client->setFilters($this->filters);
+        }
+
+        // "false" is used as a sentinel here because "null" is a valid value
+        if ($this->memoryLimitIncrease !== false) {
+            $client->setMemoryLimitIncrease($this->memoryLimitIncrease);
         }
 
         return $client;

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -298,11 +298,11 @@ class ClientFactory
 
         $client->getConfig()->mergeDeviceData(['runtimeVersions' => ['symfony' => Kernel::VERSION]]);
 
-        $client->setNotifier(array_filter([
+        $client->setNotifier([
             'name' => 'Bugsnag Symfony',
             'version' => BugsnagBundle::VERSION,
             'url' => 'https://github.com/bugsnag/bugsnag-symfony',
-        ]));
+        ]);
 
         if ($this->endpoint !== null) {
             $client->setNotifyEndpoint($this->endpoint);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -103,6 +103,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('guzzle')
                     ->defaultNull()
                 ->end()
+                ->scalarNode('memory_limit_increase')
+                    ->defaultFalse()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -28,6 +28,7 @@ services:
           - '%bugsnag.strip_path_regex%'
           - '%bugsnag.project_root_regex%'
           - '@?bugsnag.guzzle'
+          - '%bugsnag.memory_limit_increase%'
 
     bugsnag:
         class: '%bugsnag.client%'

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -241,6 +241,38 @@ final class ClientFactoryTest extends TestCase
     }
 
     /**
+     * @param int|null|false $memoryLimitIncrease
+     * @param int|null       $expected
+     *
+     * @return void
+     *
+     * @dataProvider memoryLimitIncreaseProvider
+     */
+    public function testMemoryLimitIncreaseIsSetCorrectly($memoryLimitIncrease, $expected)
+    {
+        $client = $this->createClient([
+            'memoryLimitIncrease' => $memoryLimitIncrease,
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $actual = $client->getMemoryLimitIncrease();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function memoryLimitIncreaseProvider()
+    {
+        return [
+            'null' => [null, null],
+            '1234 bytes' => [1234, 1234],
+            '20 MiB' => [1024 * 1024 * 20, 1024 * 1024 * 20],
+            '"false" uses the default' => [false, 1024 * 1024 * 5],
+        ];
+    }
+
+    /**
      * Get the value of the given property on the given object.
      *
      * @param object $object
@@ -328,6 +360,7 @@ final class ClientFactoryTest extends TestCase
             'stripPathRegex' => null,
             'projectRootRegex' => null,
             'guzzle' => null,
+            'memoryLimitIncrease' => false,
         ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.20",
+        "bugsnag/bugsnag": "^3.26.0",
         "symfony/config": "^2.7|^3|^4|^5",
         "symfony/console": "^2.7|^3|^4|^5",
         "symfony/dependency-injection": "^2.7|^3|^4|^5",


### PR DESCRIPTION
**Waiting on https://github.com/bugsnag/bugsnag-php/pull/621 to be merged & released**

---

## Goal

This PR adds OOM handling to the BugsnagListener's `onKernelException` method. The implementation is essentially the same as https://github.com/bugsnag/bugsnag-php/pull/621, but has to use a slightly different mechanism as the `Bugsnag\Handler` class isn't used in Bugsnag Symfony

This can be used in conjunction with the new `memory_limit_increase` option (see https://github.com/bugsnag/bugsnag-php/pull/621) to give Bugsnag enough headroom to send OOMs

Note: the Symfony Debug component didn't call `onKernelException` for OOMs, but the newer ErrorHandler component does. This means the OOM handling won't take affect for Symfony versions below 4.4 (when ErrorHandler was added). I've added support for Symfony 2/3 OOM exceptions anyway, because there's no real overhead of doing so

## Changeset

- Support for `memory_limit_increase` config option
- OOMs are handled by increasing the memory limit in our `onKernelException` listener

## Testing

- Unit tests
- Manual testing against various Symfony versions