### PR TITLE
Redacted keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changelog
 * Support the new `redactedKeys` configuration option. This is similar to `filters` but allows both strings and regexes. String matching is exact but case-insensitive. Regex matching allows for partial and wildcard matching.
   [#121](https://github.com/bugsnag/bugsnag-symfony/pull/121)
 
+### Deprecations
+
+* The `filters` configuration option is now deprecated as `redactedKeys` can express everything that filters could and more.
+
 ## 1.8.0 (2020-11-25)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
 * Support the new `discardClasses` configuration option. This allows events to be discarded based on the exception class name or PHP error name.
   [#120](https://github.com/bugsnag/bugsnag-symfony/pull/120)
 
+* Support the new `redactedKeys` configuration option. This is similar to `filters` but allows both strings and regexes. String matching is exact but case-insensitive. Regex matching allows for partial and wildcard matching.
+  [#121](https://github.com/bugsnag/bugsnag-symfony/pull/121)
+
 ## 1.8.0 (2020-11-25)
 
 ### Enhancements

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -202,6 +202,13 @@ class ClientFactory
     private $discardClasses;
 
     /**
+     * An array of metadata keys that should be redacted.
+     *
+     * @var string[]
+     */
+    private $redactedKeys;
+
+    /**
      * @param SymfonyResolver                    $resolver
      * @param TokenStorageInterface|null         $tokens
      * @param AuthorizationCheckerInterface|null $checker
@@ -227,6 +234,7 @@ class ClientFactory
      * @param GuzzleHttp\ClientInterface|null    $guzzle
      * @param int|null|false                     $memoryLimitIncrease
      * @param array                              $discardClasses
+     * @param string[]                           $redactedKeys
      *
      * @return void
      */
@@ -255,7 +263,8 @@ class ClientFactory
         $projectRootRegex = null,
         GuzzleHttp\ClientInterface $guzzle = null,
         $memoryLimitIncrease = false,
-        array $discardClasses = []
+        array $discardClasses = [],
+        array $redactedKeys = []
     ) {
         $this->resolver = $resolver;
         $this->tokens = $tokens;
@@ -284,6 +293,7 @@ class ClientFactory
             : $guzzle;
         $this->memoryLimitIncrease = $memoryLimitIncrease;
         $this->discardClasses = $discardClasses;
+        $this->redactedKeys = $redactedKeys;
     }
 
     /**
@@ -347,6 +357,10 @@ class ClientFactory
 
         if ($this->discardClasses) {
             $client->setDiscardClasses($this->discardClasses);
+        }
+
+        if ($this->redactedKeys) {
+            $client->setRedactedKeys($this->redactedKeys);
         }
 
         return $client;

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -149,6 +149,8 @@ class ClientFactory
     /**
      * The filters.
      *
+     * @deprecated use redactedKeys instead
+     *
      * @var string[]|null
      */
     protected $filters;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -111,6 +111,11 @@ class Configuration implements ConfigurationInterface
                     ->treatNullLike([])
                     ->defaultValue([])
                 ->end()
+                ->arrayNode('redacted_keys')
+                    ->prototype('scalar')->end()
+                    ->treatNullLike([])
+                    ->defaultValue([])
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -30,6 +30,7 @@ services:
           - '@?bugsnag.guzzle'
           - '%bugsnag.memory_limit_increase%'
           - '%bugsnag.discard_classes%'
+          - '%bugsnag.redacted_keys%'
 
     bugsnag:
         class: '%bugsnag.client%'

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -288,6 +288,22 @@ final class ClientFactoryTest extends TestCase
         $this->assertSame($discardClasses, $actual);
     }
 
+    public function testRedactedKeysIsSetCorrectly()
+    {
+        $redactedKeys = ['password', 'not_password'];
+
+        $client = $this->createClient([
+            'redactedKeys' => $redactedKeys,
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $actual = $client->getRedactedKeys();
+
+        $this->assertSame($redactedKeys, $actual);
+    }
+
     /**
      * Get the value of the given property on the given object.
      *
@@ -378,6 +394,7 @@ final class ClientFactoryTest extends TestCase
             'guzzle' => null,
             'memoryLimitIncrease' => false,
             'discardClasses' => [],
+            'redactedKeys' => [],
         ];
     }
 }


### PR DESCRIPTION
## Goal

Adds support for the new redacted keys option added in https://github.com/bugsnag/bugsnag-php/pull/623

This works similarly to `filters` but is a lot more flexible — it allows both case-insensitive string matching and regular expressions, so can express everything `filters` can and more