### PR TITLE
Release v1.9.0

### DIFF
--- a/BugsnagBundle.php
+++ b/BugsnagBundle.php
@@ -11,5 +11,5 @@ class BugsnagBundle extends Bundle
      *
      * @return string
      */
-    const VERSION = '1.8.0';
+    const VERSION = '1.9.0';
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Changelog
 * Support the new `discardClasses` configuration option. This allows events to be discarded based on the exception class name or PHP error name.
   [#120](https://github.com/bugsnag/bugsnag-symfony/pull/120)
 
+* Support the new `redactedKeys` configuration option. This is similar to `filters` but allows both strings and regexes. String matching is exact but case-insensitive. Regex matching allows for partial and wildcard matching.
+  [#121](https://github.com/bugsnag/bugsnag-symfony/pull/121)
+
+### Deprecations
+
+* The `filters` configuration option is now deprecated as `redactedKeys` can express everything that filters could and more.
+
 ## 1.8.0 (2020-11-25)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Out of memory errors will now be reported by increasing the memory limit by 5 MiB. Use the new `memoryLimitIncrease` configuration option to change the amount of memory, or set it to `null` to disable the increase entirely.
+  [#119](https://github.com/bugsnag/bugsnag-symfony/pull/119)
+
 ## 1.8.0 (2020-11-25)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 1.9.0 (2021-02-10)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Out of memory errors will now be reported by increasing the memory limit by 5 MiB. Use the new `memoryLimitIncrease` configuration option to change the amount of memory, or set it to `null` to disable the increase entirely.
   [#119](https://github.com/bugsnag/bugsnag-symfony/pull/119)
 
+* Support the new `discardClasses` configuration option. This allows events to be discarded based on the exception class name or PHP error name.
+  [#120](https://github.com/bugsnag/bugsnag-symfony/pull/120)
+
 ## 1.8.0 (2020-11-25)
 
 ### Enhancements

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -193,6 +193,15 @@ class ClientFactory
     private $memoryLimitIncrease;
 
     /**
+     * An array of classes that should not be sent to Bugsnag.
+     *
+     * This can contain both fully qualified class names and regular expressions.
+     *
+     * @var array
+     */
+    private $discardClasses;
+
+    /**
      * @param SymfonyResolver                    $resolver
      * @param TokenStorageInterface|null         $tokens
      * @param AuthorizationCheckerInterface|null $checker
@@ -217,6 +226,7 @@ class ClientFactory
      * @param string|null                        $projectRootRegex
      * @param GuzzleHttp\ClientInterface|null    $guzzle
      * @param int|null|false                     $memoryLimitIncrease
+     * @param array                              $discardClasses
      *
      * @return void
      */
@@ -244,7 +254,8 @@ class ClientFactory
         $stripPathRegex = null,
         $projectRootRegex = null,
         GuzzleHttp\ClientInterface $guzzle = null,
-        $memoryLimitIncrease = false
+        $memoryLimitIncrease = false,
+        array $discardClasses = []
     ) {
         $this->resolver = $resolver;
         $this->tokens = $tokens;
@@ -272,6 +283,7 @@ class ClientFactory
             ? Client::makeGuzzle()
             : $guzzle;
         $this->memoryLimitIncrease = $memoryLimitIncrease;
+        $this->discardClasses = $discardClasses;
     }
 
     /**
@@ -331,6 +343,10 @@ class ClientFactory
         // "false" is used as a sentinel here because "null" is a valid value
         if ($this->memoryLimitIncrease !== false) {
             $client->setMemoryLimitIncrease($this->memoryLimitIncrease);
+        }
+
+        if ($this->discardClasses) {
+            $client->setDiscardClasses($this->discardClasses);
         }
 
         return $client;

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -149,6 +149,8 @@ class ClientFactory
     /**
      * The filters.
      *
+     * @deprecated use redactedKeys instead
+     *
      * @var string[]|null
      */
     protected $filters;
@@ -202,6 +204,13 @@ class ClientFactory
     private $discardClasses;
 
     /**
+     * An array of metadata keys that should be redacted.
+     *
+     * @var string[]
+     */
+    private $redactedKeys;
+
+    /**
      * @param SymfonyResolver                    $resolver
      * @param TokenStorageInterface|null         $tokens
      * @param AuthorizationCheckerInterface|null $checker
@@ -227,6 +236,7 @@ class ClientFactory
      * @param GuzzleHttp\ClientInterface|null    $guzzle
      * @param int|null|false                     $memoryLimitIncrease
      * @param array                              $discardClasses
+     * @param string[]                           $redactedKeys
      *
      * @return void
      */
@@ -255,7 +265,8 @@ class ClientFactory
         $projectRootRegex = null,
         GuzzleHttp\ClientInterface $guzzle = null,
         $memoryLimitIncrease = false,
-        array $discardClasses = []
+        array $discardClasses = [],
+        array $redactedKeys = []
     ) {
         $this->resolver = $resolver;
         $this->tokens = $tokens;
@@ -284,6 +295,7 @@ class ClientFactory
             : $guzzle;
         $this->memoryLimitIncrease = $memoryLimitIncrease;
         $this->discardClasses = $discardClasses;
+        $this->redactedKeys = $redactedKeys;
     }
 
     /**
@@ -347,6 +359,10 @@ class ClientFactory
 
         if ($this->discardClasses) {
             $client->setDiscardClasses($this->discardClasses);
+        }
+
+        if ($this->redactedKeys) {
+            $client->setRedactedKeys($this->redactedKeys);
         }
 
         return $client;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -106,6 +106,11 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('memory_limit_increase')
                     ->defaultFalse()
                 ->end()
+                ->arrayNode('discard_classes')
+                    ->prototype('scalar')->end()
+                    ->treatNullLike([])
+                    ->defaultValue([])
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -111,6 +111,11 @@ class Configuration implements ConfigurationInterface
                     ->treatNullLike([])
                     ->defaultValue([])
                 ->end()
+                ->arrayNode('redacted_keys')
+                    ->prototype('scalar')->end()
+                    ->treatNullLike([])
+                    ->defaultValue([])
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -103,6 +103,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('guzzle')
                     ->defaultNull()
                 ->end()
+                ->scalarNode('memory_limit_increase')
+                    ->defaultFalse()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -30,6 +30,7 @@ services:
           - '@?bugsnag.guzzle'
           - '%bugsnag.memory_limit_increase%'
           - '%bugsnag.discard_classes%'
+          - '%bugsnag.redacted_keys%'
 
     bugsnag:
         class: '%bugsnag.client%'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -29,6 +29,7 @@ services:
           - '%bugsnag.project_root_regex%'
           - '@?bugsnag.guzzle'
           - '%bugsnag.memory_limit_increase%'
+          - '%bugsnag.discard_classes%'
 
     bugsnag:
         class: '%bugsnag.client%'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -28,6 +28,7 @@ services:
           - '%bugsnag.strip_path_regex%'
           - '%bugsnag.project_root_regex%'
           - '@?bugsnag.guzzle'
+          - '%bugsnag.memory_limit_increase%'
 
     bugsnag:
         class: '%bugsnag.client%'

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -272,6 +272,22 @@ final class ClientFactoryTest extends TestCase
         ];
     }
 
+    public function testDiscardClassesIsSetCorrectly()
+    {
+        $discardClasses = [\LogicException::class, \RuntimeException::class];
+
+        $client = $this->createClient([
+            'discardClasses' => $discardClasses,
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $actual = $client->getDiscardClasses();
+
+        $this->assertSame($discardClasses, $actual);
+    }
+
     /**
      * Get the value of the given property on the given object.
      *
@@ -361,6 +377,7 @@ final class ClientFactoryTest extends TestCase
             'projectRootRegex' => null,
             'guzzle' => null,
             'memoryLimitIncrease' => false,
+            'discardClasses' => [],
         ];
     }
 }

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -241,6 +241,38 @@ final class ClientFactoryTest extends TestCase
     }
 
     /**
+     * @param int|null|false $memoryLimitIncrease
+     * @param int|null       $expected
+     *
+     * @return void
+     *
+     * @dataProvider memoryLimitIncreaseProvider
+     */
+    public function testMemoryLimitIncreaseIsSetCorrectly($memoryLimitIncrease, $expected)
+    {
+        $client = $this->createClient([
+            'memoryLimitIncrease' => $memoryLimitIncrease,
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $actual = $client->getMemoryLimitIncrease();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function memoryLimitIncreaseProvider()
+    {
+        return [
+            'null' => [null, null],
+            '1234 bytes' => [1234, 1234],
+            '20 MiB' => [1024 * 1024 * 20, 1024 * 1024 * 20],
+            '"false" uses the default' => [false, 1024 * 1024 * 5],
+        ];
+    }
+
+    /**
      * Get the value of the given property on the given object.
      *
      * @param object $object
@@ -328,6 +360,7 @@ final class ClientFactoryTest extends TestCase
             'stripPathRegex' => null,
             'projectRootRegex' => null,
             'guzzle' => null,
+            'memoryLimitIncrease' => false,
         ];
     }
 }

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -288,6 +288,22 @@ final class ClientFactoryTest extends TestCase
         $this->assertSame($discardClasses, $actual);
     }
 
+    public function testRedactedKeysIsSetCorrectly()
+    {
+        $redactedKeys = ['password', 'not_password'];
+
+        $client = $this->createClient([
+            'redactedKeys' => $redactedKeys,
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $actual = $client->getRedactedKeys();
+
+        $this->assertSame($redactedKeys, $actual);
+    }
+
     /**
      * Get the value of the given property on the given object.
      *
@@ -378,6 +394,7 @@ final class ClientFactoryTest extends TestCase
             'guzzle' => null,
             'memoryLimitIncrease' => false,
             'discardClasses' => [],
+            'redactedKeys' => [],
         ];
     }
 }

--- a/Tests/Listener/BugsnagListenerTest.php
+++ b/Tests/Listener/BugsnagListenerTest.php
@@ -10,12 +10,15 @@ use Exception;
 use GrahamCampbell\TestBenchCore\MockeryTrait;
 use InvalidArgumentException;
 use Mockery;
+use Mockery\MockInterface as Mock;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 use Symfony\Component\Console\Event\ConsoleExceptionEvent;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Debug\Exception\OutOfMemoryException as OutOfMemorySymfony2Or3;
+use Symfony\Component\ErrorHandler\Error\OutOfMemoryError as OutOfMemorySymfony4Plus;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
 class ReportStub
@@ -29,35 +32,77 @@ class BugsnagListenerTest extends TestCase
 
     public function testOnKernelException()
     {
-        // Create mocks
+        /** @var Mock&Report $report */
         $report = Mockery::namedMock(Report::class, ReportStub::class);
+        /** @var Mock&Client $client */
         $client = Mockery::mock(Client::class);
+        /** @var Mock&GetResponseForExceptionEvent $event */
         $event = Mockery::mock(GetResponseForExceptionEvent::class);
-        $resolver = Mockery::mock(SymfonyResolver::class);
 
-        // Setup responses
-        $event->shouldReceive('getException')->once()->andReturn('exception');
-        $report->shouldReceive('fromPHPThrowable')
-            ->with('config', 'exception')
-            ->once()
-            ->andReturn($report);
+        $resolver = new SymfonyResolver();
+        $exception = new Exception('oh no');
+
+        $event->shouldReceive('getException')->once()->andReturn($exception);
+        $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
         $report->shouldReceive('setUnhandled')->once()->with(true);
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
         $report->shouldReceive('setMetaData')->once()->with([]);
         $client->shouldReceive('notify')->once()->with($report);
 
-        // Initiate test
+        $listener = new BugsnagListener($client, $resolver, true);
+        $listener->onKernelException($event);
+    }
+
+    public function testOnKernelExceptionWithAnOom()
+    {
+        $file = __FILE__;
+        $line = __LINE__;
+        $oomMessage = 'Allowed memory size of 12345 bytes exhausted (tried to allocate 9876 bytes)';
+
+        if (class_exists(OutOfMemorySymfony4Plus::class)) {
+            $error = [
+                'type' => E_ERROR,
+                'message' => $oomMessage,
+                'file' => $file,
+                'line' => $line,
+            ];
+
+            $oom = new OutOfMemorySymfony4Plus($oomMessage, 1, $error);
+        } else {
+            $oom = new OutOfMemorySymfony2Or3($oomMessage, 1, E_ERROR, $file, $line);
+        }
+
+        /** @var Mock&Report $report */
+        $report = Mockery::namedMock(Report::class, ReportStub::class);
+        /** @var Mock&Client $client */
+        $client = Mockery::mock(Client::class);
+        /** @var Mock&GetResponseForExceptionEvent $event */
+        $event = Mockery::mock(GetResponseForExceptionEvent::class);
+
+        $resolver = new SymfonyResolver();
+
+        $event->shouldReceive('getException')->once()->andReturn($oom);
+
+        $report->shouldReceive('fromPHPThrowable')->once()->with('config', $oom)->andReturn($report);
+        $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
+        $report->shouldReceive('setMetaData')->once()->with([]);
+
+        $client->shouldReceive('getConfig')->once()->andReturn('config');
+        $client->shouldReceive('getMemoryLimitIncrease')->twice()->andReturn(1234567890);
+        $client->shouldReceive('notify')->once()->with($report);
+
         $listener = new BugsnagListener($client, $resolver, true);
         $listener->onKernelException($event);
     }
 
     public function testOnRequestArgumentException()
     {
-        // Create mocks
+        /** @var Mock&Client $client */
         $client = Mockery::mock(Client::class);
-        $event = Mockery::mock(GetResponseForExceptionEvent::class);
-        $resolver = Mockery::mock(SymfonyResolver::class);
+
+        $resolver = new SymfonyResolver();
 
         // PHPUnit 4 doesn't have 'expectException'
         if (method_exists(TestCase::class, 'expectException')) {
@@ -66,62 +111,57 @@ class BugsnagListenerTest extends TestCase
             $this->setExpectedException(InvalidArgumentException::class);
         }
 
-        // Initiate test
         $listener = new BugsnagListener($client, $resolver, true);
         $listener->onKernelRequest('This should throw an exception');
     }
 
     public function testOnConsoleError()
     {
-        if (!class_exists('Symfony\Component\Console\Event\ConsoleErrorEvent')) {
-            $this->markTestSkipped('ConsoleErrorEvent class not present - pre-Symfony3.3');
-        } else {
-            // Create mocks
-            $report = Mockery::namedMock(Report::class, ReportStub::class);
-            $client = Mockery::mock(Client::class);
-            $input = Mockery::mock(InputInterface::class);
-            $output = Mockery::mock(OutputInterface::class);
-            $command = Mockery::mock(Command::class);
-            $event = new ConsoleErrorEvent($input, $output, new Exception(), $command); // Unable to mock as final
-            $event->setExitCode(1);
-            $resolver = Mockery::mock(SymfonyResolver::class);
-
-            // Setup responses
-            $command->shouldReceive('getName')->once()->andReturn('test');
-            $report->shouldReceive('setMetaData')->once()->with(['command' => ['name' => 'test', 'status' => 1]]);
-            $report->shouldReceive('fromPHPThrowable')
-                ->with('config', 'exception')
-                ->once()
-                ->andReturn($report);
-            $report->shouldReceive('setUnhandled')->once()->with(true);
-            $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
-            $client->shouldReceive('getConfig')->once()->andReturn('config');
-            $client->shouldReceive('notify')->once()->with($report);
-
-            // Initiate test
-            $listener = new BugsnagListener($client, $resolver, true);
-            $listener->onConsoleError($event);
+        if (!class_exists(ConsoleErrorEvent::class)) {
+            $this->markTestSkipped('ConsoleErrorEvent class not present');
         }
+
+        /** @var Mock&Report $report */
+        $report = Mockery::namedMock(Report::class, ReportStub::class);
+        /** @var Mock&Client $client */
+        $client = Mockery::mock(Client::class);
+
+        $resolver = new SymfonyResolver();
+        $exception = new Exception('oh no');
+
+        $event = new ConsoleErrorEvent(new StringInput(''), new NullOutput(), $exception, new Command('test'));
+        $event->setExitCode(1);
+
+        // Setup responses
+        $report->shouldReceive('setMetaData')->once()->with(['command' => ['name' => 'test', 'status' => 1]]);
+        $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
+        $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
+        $client->shouldReceive('getConfig')->once()->andReturn('config');
+        $client->shouldReceive('notify')->once()->with($report);
+
+        // Initiate test
+        $listener = new BugsnagListener($client, $resolver, true);
+        $listener->onConsoleError($event);
     }
 
     public function testOnConsoleException()
     {
-        // Create mocks
+        if (!class_exists(ConsoleExceptionEvent::class)) {
+            $this->markTestSkipped('ConsoleExceptionEvent class not present');
+        }
+
+        /** @var Mock&Report $report */
         $report = Mockery::namedMock(Report::class, ReportStub::class);
+        /** @var Mock&Client $client */
         $client = Mockery::mock(Client::class);
-        $event = Mockery::mock(ConsoleExceptionEvent::class);
-        $resolver = Mockery::mock(SymfonyResolver::class);
+
+        $exception = new Exception('oh no');
+        $resolver = new SymfonyResolver();
+        $event = new ConsoleExceptionEvent(new Command('test'), new StringInput(''), new NullOutput(), $exception, 1);
 
         // Setup responses
-        $event->shouldReceive('getException')->once()->andReturn('exception');
-        $event->shouldReceive('getCommand')->twice()->andReturn($event);
-        $event->shouldReceive('getName')->once()->andReturn('test');
-        $event->shouldReceive('getExitCode')->once()->andReturn(1);
-
-        $report->shouldReceive('fromPHPThrowable')
-            ->with('config', 'exception')
-            ->once()
-            ->andReturn($report);
+        $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
         $report->shouldReceive('setMetaData')->once()->with(['command' => ['name' => 'test', 'status' => 1]]);
         $report->shouldReceive('setUnhandled')->once()->with(true);
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "bugsnag/bugsnag": "^3.20",
+        "bugsnag/bugsnag": "^3.26.0",
         "symfony/config": "^2.7|^3|^4|^5",
         "symfony/console": "^2.7|^3|^4|^5",
         "symfony/dependency-injection": "^2.7|^3|^4|^5",


### PR DESCRIPTION
## 1.9.0 (2021-02-10)

### Enhancements

* Out of memory errors will now be reported by increasing the memory limit by 5 MiB. Use the new `memoryLimitIncrease` configuration option to change the amount of memory, or set it to `null` to disable the increase entirely.
  [#119](https://github.com/bugsnag/bugsnag-symfony/pull/119)

* Support the new `discardClasses` configuration option. This allows events to be discarded based on the exception class name or PHP error name.
  [#120](https://github.com/bugsnag/bugsnag-symfony/pull/120)

* Support the new `redactedKeys` configuration option. This is similar to `filters` but allows both strings and regexes. String matching is exact but case-insensitive. Regex matching allows for partial and wildcard matching.
  [#121](https://github.com/bugsnag/bugsnag-symfony/pull/121)
