### PR TITLE
Using hasPreviousSession in getSession to avoid initializing session …

### DIFF
--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -44,7 +44,7 @@ class SymfonyRequest implements RequestInterface
     public function getSession()
     {
         $session = null;
-        if ($this->request->hasSession()) {
+        if ($this->request->hasPreviousSession()) {
             $session = $this->request->getSession();
         }
 


### PR DESCRIPTION
…if it does not exists in the current request

## Goal

Avoid initializing session, if it does not exists in the current request

## Design

The default usage of `hasPreviousSession`

## Changeset

`getSession` uses `hasPreviousSession` to detect session

## Testing

Automated.