### PR TITLE
Support Symfony Messenger

### DIFF
--- a/.ci/require-symfony.sh
+++ b/.ci/require-symfony.sh
@@ -38,6 +38,7 @@ if [ "$SYMFONY_VERSION" = "latest" ]; then
     composer require "symfony/http-foundation:$(lastversion symfony/http-foundation --pre)" --no-update
     composer require "symfony/http-kernel:$(lastversion symfony/http-kernel --pre)" --no-update
     composer require "symfony/security-core:$(lastversion symfony/security-core --pre)" --no-update
+    composer require "symfony/messenger:$(lastversion symfony/messenger --pre)" --no-update
 else
     # If we're requesting a specific version we can simply install it
     composer require "symfony/config:${SYMFONY_VERSION}" --no-update
@@ -46,4 +47,10 @@ else
     composer require "symfony/http-foundation:${SYMFONY_VERSION}" --no-update
     composer require "symfony/http-kernel:${SYMFONY_VERSION}" --no-update
     composer require "symfony/security-core:${SYMFONY_VERSION}" --no-update
+
+    # Symfony Messenger only exists from 4.1.0 onward
+    case "$SYMFONY_VERSION" in
+        4.0*) ;;
+        ^[4-5]*) composer require "symfony/messenger:${SYMFONY_VERSION}" --no-update ;;
+    esac
 fi

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -37,23 +37,31 @@ jobs:
           - php-version: 7.1
             symfony-version: '^3.0'
           - php-version: 7.1
+            symfony-version: '4.0.*'
+          - php-version: 7.1
             symfony-version: '^4.0'
           - php-version: 7.2
             symfony-version: '2.8.*'
           - php-version: 7.2
             symfony-version: '^3.0'
           - php-version: 7.2
+            symfony-version: '4.0.*'
+          - php-version: 7.2
             symfony-version: '^4.0'
           - php-version: 7.2
             symfony-version: '^5.0'
           - php-version: 7.3
             symfony-version: '^3.0'
           - php-version: 7.3
+            symfony-version: '4.0.*'
+          - php-version: 7.3
             symfony-version: '^4.0'
           - php-version: 7.3
             symfony-version: '^5.0'
           - php-version: 7.4
             symfony-version: '^3.0'
+          - php-version: 7.4
+            symfony-version: '4.0.*'
           - php-version: 7.4
             symfony-version: '^4.0'
           - php-version: 7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Add support for Symfony Messenger. Exceptions in workers will now automatically be reported to Bugsnag. The queue of events will also be flushed after each successful job
+  [Mathieu](https://github.com/MatTheCat)
+  [#89](https://github.com/bugsnag/bugsnag-symfony/pull/89)
+  [#125](https://github.com/bugsnag/bugsnag-symfony/pull/125)
+
 ### Bug Fixes
 
 * Use `hasPreviousSession` instead of `hasSession` when checking for session data

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -155,11 +155,10 @@ class BugsnagListener implements EventSubscriberInterface
      */
     public function onWorkerMessageFailed(WorkerMessageFailedEvent $event)
     {
-        if ($event->willRetry()) {
-            return;
-        }
-
-        $this->sendNotify($event->getThrowable(), []);
+        $this->sendNotify(
+            $event->getThrowable(),
+            ['Messenger' => ['willRetry' => $event->willRetry()]]
+        );
 
         // Normally we flush after a message has been handled, but this event
         // doesn't fire for failed messages so we have to flush here instead


### PR DESCRIPTION
## Goal

Building off of #89, this PR adds support for Symfony Messenger. Primarily this involves listening for a `WorkerMessageFailedEvent` (caused by unhandled errors in a job) and notifying when this happens. However, this doesn't quite work because of batch sending mode , where we flush the queue of events on shutdown. Worker processes are generally long lived and therefore won't trigger this flush often, which means events would end up not being delivered

To fix this, we flush the queue after a `WorkerMessageFailedEvent`, which will send the event from the failure and any manual notify calls. We also flush the queue after each job finishes by listening for `WorkerMessageHandledEvent` in order to send manual notify calls when jobs succeed

We will report jobs that will be retried, because a failed job could indicate a problem even if it eventually succeeds. This is alos what we do on other platforms, e.g. Sidekiq in Ruby. The `willRetry` flag is added as metadata under the `Messenger` key, so jobs that will be retried can be ignored with a simple callback:

```php
$bugsnag->registerCallback(function (Report $report) {
    $metadata = $report->getMetaData();

    if (isset($metadata['Messenger']['willRetry'])
        && $metadata['Messenger']['willRetry']
    ) {
        return false;
    }
});
```

## Changeset

- add `symfony/messenger` to CI
- add Symfony 4.0.* to CI matrix (as messenger was added in 4.1)
- add listener for `WorkerMessageFailedEvent` to notify on failure
- add listener for `WorkerMessageHandledEvent` to flush on success