### PR TITLE
Give events a severity of 'error'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changelog
   [Oleg Andreyev](https://github.com/oleg-andreyev)
   [#124](https://github.com/bugsnag/bugsnag-symfony/pull/124)
 
+* Set the severity of exceptions to "error" instead of "warning"
+  [#126](https://github.com/bugsnag/bugsnag-symfony/pull/126)
+
 ## 1.9.0 (2021-02-10)
 
 ### Enhancements

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -198,6 +198,7 @@ class BugsnagListener implements EventSubscriberInterface
             $throwable
         );
         $report->setUnhandled(true);
+        $report->setSeverity('error');
         $report->setSeverityReason([
             'type' => 'unhandledExceptionMiddleware',
             'attributes' => [

--- a/Tests/Listener/BugsnagListenerTest.php
+++ b/Tests/Listener/BugsnagListenerTest.php
@@ -55,6 +55,7 @@ class BugsnagListenerTest extends TestCase
         $event->shouldReceive('getException')->once()->andReturn($exception);
         $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
         $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverity')->once()->with('error');
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
         $report->shouldReceive('setMetaData')->once()->with([]);
@@ -99,6 +100,7 @@ class BugsnagListenerTest extends TestCase
 
         $report->shouldReceive('fromPHPThrowable')->once()->with('config', $oom)->andReturn($report);
         $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverity')->once()->with('error');
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $report->shouldReceive('setMetaData')->once()->with([]);
 
@@ -155,6 +157,7 @@ class BugsnagListenerTest extends TestCase
         $report->shouldReceive('setMetaData')->once()->with(['command' => ['name' => 'test', 'status' => 1]]);
         $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
         $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverity')->once()->with('error');
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
         $client->shouldReceive('notify')->once()->with($report);
@@ -186,6 +189,7 @@ class BugsnagListenerTest extends TestCase
         $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
         $report->shouldReceive('setMetaData')->once()->with(['command' => ['name' => 'test', 'status' => 1]]);
         $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverity')->once()->with('error');
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
         $client->shouldReceive('notify')->once()->with($report);
@@ -215,7 +219,7 @@ class BugsnagListenerTest extends TestCase
             ->with($this->callback(function (Report $report) use ($exception) {
                 $this->assertSame($exception->getMessage(), $report->getMessage());
                 $this->assertTrue($report->getUnhandled());
-                $this->assertSame('warning', $report->getSeverity());
+                $this->assertSame('error', $report->getSeverity());
                 $this->assertSame(
                     [
                         'type' => 'unhandledExceptionMiddleware',
@@ -265,7 +269,7 @@ class BugsnagListenerTest extends TestCase
             ->with($this->callback(function (Report $report) use ($exception) {
                 $this->assertSame($exception->getMessage(), $report->getMessage());
                 $this->assertTrue($report->getUnhandled());
-                $this->assertSame('warning', $report->getSeverity());
+                $this->assertSame('error', $report->getSeverity());
                 $this->assertSame(
                     [
                         'type' => 'unhandledExceptionMiddleware',


### PR DESCRIPTION
## Goal

Currently we don't explicitly set a severity on events we capture, so they default to 'warning'. For consistency with other notifiers and because we're only dealing with unhandled errors, this should be 'error'