### PR TITLE
Release v1.10.0

### DIFF
--- a/.ci/require-symfony.sh
+++ b/.ci/require-symfony.sh
@@ -38,6 +38,7 @@ if [ "$SYMFONY_VERSION" = "latest" ]; then
     composer require "symfony/http-foundation:$(lastversion symfony/http-foundation --pre)" --no-update
     composer require "symfony/http-kernel:$(lastversion symfony/http-kernel --pre)" --no-update
     composer require "symfony/security-core:$(lastversion symfony/security-core --pre)" --no-update
+    composer require "symfony/messenger:$(lastversion symfony/messenger --pre)" --no-update
 else
     # If we're requesting a specific version we can simply install it
     composer require "symfony/config:${SYMFONY_VERSION}" --no-update
@@ -46,4 +47,10 @@ else
     composer require "symfony/http-foundation:${SYMFONY_VERSION}" --no-update
     composer require "symfony/http-kernel:${SYMFONY_VERSION}" --no-update
     composer require "symfony/security-core:${SYMFONY_VERSION}" --no-update
+
+    # Symfony Messenger only exists from 4.1.0 onward
+    case "$SYMFONY_VERSION" in
+        4.0*) ;;
+        ^[4-5]*) composer require "symfony/messenger:${SYMFONY_VERSION}" --no-update ;;
+    esac
 fi

--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -1,0 +1,35 @@
+name: Audit bugsnag-symfony dependency licenses
+
+on: [push, pull_request]
+
+jobs:
+  license-audit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        symfony-version: ['^3.4', '^4.4', '^5.0']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.0'
+
+    - name: Fetch decisions.yml
+      run: curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o decisions.yml
+
+    - name: Require Symfony
+      run: ./.ci/require-symfony.sh "${{ matrix.symfony-version }}"
+
+    - name: Install dependencies
+      run: composer update --prefer-dist --no-progress --no-suggest --no-interaction --no-dev
+
+    - name: Run License Finder
+      # for some reason license finder doesn't run without a login shell (-l)
+      run: >
+        docker run -v $PWD:/scan licensefinder/license_finder /bin/bash -lc "
+          cd /scan &&
+          license_finder --decisions-file decisions.yml --composer-check-require-only=true --enabled-package-managers=composer
+        "

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -37,23 +37,31 @@ jobs:
           - php-version: 7.1
             symfony-version: '^3.0'
           - php-version: 7.1
+            symfony-version: '4.0.*'
+          - php-version: 7.1
             symfony-version: '^4.0'
           - php-version: 7.2
             symfony-version: '2.8.*'
           - php-version: 7.2
             symfony-version: '^3.0'
           - php-version: 7.2
+            symfony-version: '4.0.*'
+          - php-version: 7.2
             symfony-version: '^4.0'
           - php-version: 7.2
             symfony-version: '^5.0'
           - php-version: 7.3
             symfony-version: '^3.0'
           - php-version: 7.3
+            symfony-version: '4.0.*'
+          - php-version: 7.3
             symfony-version: '^4.0'
           - php-version: 7.3
             symfony-version: '^5.0'
           - php-version: 7.4
             symfony-version: '^3.0'
+          - php-version: 7.4
+            symfony-version: '4.0.*'
           - php-version: 7.4
             symfony-version: '^4.0'
           - php-version: 7.4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /composer.phar
 /.idea
 .phpunit.result.cache
+decisions.yml

--- a/BugsnagBundle.php
+++ b/BugsnagBundle.php
@@ -11,5 +11,5 @@ class BugsnagBundle extends Bundle
      *
      * @return string
      */
-    const VERSION = '1.9.0';
+    const VERSION = '1.10.0';
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changelog
   [Oleg Andreyev](https://github.com/oleg-andreyev)
   [#124](https://github.com/bugsnag/bugsnag-symfony/pull/124)
 
+* Set the severity of exceptions to "error" instead of "warning"
+  [#126](https://github.com/bugsnag/bugsnag-symfony/pull/126)
+
 ## 1.9.0 (2021-02-10)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Use `hasPreviousSession` instead of `hasSession` when checking for session data
+  [Oleg Andreyev](https://github.com/oleg-andreyev)
+  [#124](https://github.com/bugsnag/bugsnag-symfony/pull/124)
+
 ## 1.9.0 (2021-02-10)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Add support for Symfony Messenger. Exceptions in workers will now automatically be reported to Bugsnag. The queue of events will also be flushed after each successful job
+  [Mathieu](https://github.com/MatTheCat)
+  [#89](https://github.com/bugsnag/bugsnag-symfony/pull/89)
+  [#125](https://github.com/bugsnag/bugsnag-symfony/pull/125)
+
 ### Bug Fixes
 
 * Use `hasPreviousSession` instead of `hasSession` when checking for session data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 1.10.0 (2021-06-30)
 
 ### Enhancements
 

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -198,6 +198,7 @@ class BugsnagListener implements EventSubscriberInterface
             $throwable
         );
         $report->setUnhandled(true);
+        $report->setSeverity('error');
         $report->setSeverityReason([
             'type' => 'unhandledExceptionMiddleware',
             'attributes' => [

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 
 class BugsnagListener implements EventSubscriberInterface
 {
@@ -145,6 +147,41 @@ class BugsnagListener implements EventSubscriberInterface
     }
 
     /**
+     * Handle a failing message.
+     *
+     * @param \Symfony\Component\Messenger\Event\WorkerMessageFailedEvent $event
+     *
+     * @return void
+     */
+    public function onWorkerMessageFailed(WorkerMessageFailedEvent $event)
+    {
+        $this->sendNotify(
+            $event->getThrowable(),
+            ['Messenger' => ['willRetry' => $event->willRetry()]]
+        );
+
+        // Normally we flush after a message has been handled, but this event
+        // doesn't fire for failed messages so we have to flush here instead
+        $this->client->flush();
+    }
+
+    /**
+     * Flush any accumulated reports after a message has been handled.
+     *
+     * In batch sending mode reports are usually sent on shutdown but workers
+     * are (generally) long running processes so this doesn't work. Instead we
+     * flush after each handled message
+     *
+     * @param WorkerMessageHandledEvent $event
+     *
+     * @return void
+     */
+    public function onWorkerMessageHandled(WorkerMessageHandledEvent $event)
+    {
+        $this->client->flush();
+    }
+
+    /**
      * @param \Throwable $throwable
      * @param array      $meta
      *
@@ -225,6 +262,16 @@ class BugsnagListener implements EventSubscriberInterface
             } else {
                 $listeners[ConsoleEvents::EXCEPTION] = ['onConsoleException', 128];
             }
+        }
+
+        if (class_exists(WorkerMessageFailedEvent::class)) {
+            // This must run after Symfony's "SendFailedMessageForRetryListener"
+            // as it sets the "willRetry" flag
+            $listeners[WorkerMessageFailedEvent::class] = ['onWorkerMessageFailed', 64];
+        }
+
+        if (class_exists(WorkerMessageHandledEvent::class)) {
+            $listeners[WorkerMessageHandledEvent::class] = ['onWorkerMessageHandled', 128];
         }
 
         return $listeners;

--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -44,7 +44,7 @@ class SymfonyRequest implements RequestInterface
     public function getSession()
     {
         $session = null;
-        if ($this->request->hasSession()) {
+        if ($this->request->hasPreviousSession()) {
             $session = $this->request->getSession();
         }
 

--- a/Tests/Listener/BugsnagListenerTest.php
+++ b/Tests/Listener/BugsnagListenerTest.php
@@ -55,6 +55,7 @@ class BugsnagListenerTest extends TestCase
         $event->shouldReceive('getException')->once()->andReturn($exception);
         $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
         $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverity')->once()->with('error');
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
         $report->shouldReceive('setMetaData')->once()->with([]);
@@ -99,6 +100,7 @@ class BugsnagListenerTest extends TestCase
 
         $report->shouldReceive('fromPHPThrowable')->once()->with('config', $oom)->andReturn($report);
         $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverity')->once()->with('error');
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $report->shouldReceive('setMetaData')->once()->with([]);
 
@@ -155,6 +157,7 @@ class BugsnagListenerTest extends TestCase
         $report->shouldReceive('setMetaData')->once()->with(['command' => ['name' => 'test', 'status' => 1]]);
         $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
         $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverity')->once()->with('error');
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
         $client->shouldReceive('notify')->once()->with($report);
@@ -186,6 +189,7 @@ class BugsnagListenerTest extends TestCase
         $report->shouldReceive('fromPHPThrowable')->once()->with('config', $exception)->andReturn($report);
         $report->shouldReceive('setMetaData')->once()->with(['command' => ['name' => 'test', 'status' => 1]]);
         $report->shouldReceive('setUnhandled')->once()->with(true);
+        $report->shouldReceive('setSeverity')->once()->with('error');
         $report->shouldReceive('setSeverityReason')->once()->with(['type' => 'unhandledExceptionMiddleware', 'attributes' => ['framework' => 'Symfony']]);
         $client->shouldReceive('getConfig')->once()->andReturn('config');
         $client->shouldReceive('notify')->once()->with($report);
@@ -215,7 +219,7 @@ class BugsnagListenerTest extends TestCase
             ->with($this->callback(function (Report $report) use ($exception) {
                 $this->assertSame($exception->getMessage(), $report->getMessage());
                 $this->assertTrue($report->getUnhandled());
-                $this->assertSame('warning', $report->getSeverity());
+                $this->assertSame('error', $report->getSeverity());
                 $this->assertSame(
                     [
                         'type' => 'unhandledExceptionMiddleware',
@@ -265,7 +269,7 @@ class BugsnagListenerTest extends TestCase
             ->with($this->callback(function (Report $report) use ($exception) {
                 $this->assertSame($exception->getMessage(), $report->getMessage());
                 $this->assertTrue($report->getUnhandled());
-                $this->assertSame('warning', $report->getSeverity());
+                $this->assertSame('error', $report->getSeverity());
                 $this->assertSame(
                     [
                         'type' => 'unhandledExceptionMiddleware',


### PR DESCRIPTION
### Enhancements

* Add support for Symfony Messenger. Exceptions in workers will now automatically be reported to Bugsnag. The queue of events will also be flushed after each successful job
  [Mathieu](https://github.com/MatTheCat)
  [#89](https://github.com/bugsnag/bugsnag-symfony/pull/89)
  [#125](https://github.com/bugsnag/bugsnag-symfony/pull/125)

### Bug Fixes

* Use `hasPreviousSession` instead of `hasSession` when checking for session data
  [Oleg Andreyev](https://github.com/oleg-andreyev)
  [#124](https://github.com/bugsnag/bugsnag-symfony/pull/124)

* Set the severity of exceptions to "error" instead of "warning"
  [#126](https://github.com/bugsnag/bugsnag-symfony/pull/126)