### PR TITLE
Fix installation of the latest Symfony version on CI

### DIFF
--- a/.ci/require-symfony.sh
+++ b/.ci/require-symfony.sh
@@ -29,7 +29,7 @@ SYMFONY_VERSION=$1
 if [ "$SYMFONY_VERSION" = "latest" ]; then
     if ! [ "$(command -v lastversion)" ]; then
         # Install "lastversion" if it's not already installed
-        pip install lastversion==v1.1.5
+        pip install lastversion==v1.6.0
     fi
 
     composer require "symfony/config:$(lastversion symfony/config --pre)" --no-update


### PR DESCRIPTION
## Goal

This fixes an issue where the `lastversion` tool could actually return an older version if that version was the most recently published. Updating to the latest version fixes this as it now looks at previous version numbers too

This was causing us to install symfony/config v4.4.30 when we should be installing v5.3.4, which created conflicting dependencies and caused Composer to fail

Note: CI is currently failing on PHP 8.1; this is an issue with bugsnag-php, not something we can fix in this repo