### PR TITLE
Remove Symfony latest on PHP 7.4

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -66,8 +66,6 @@ jobs:
             symfony-version: '^4.0'
           - php-version: '7.4'
             symfony-version: '^5.0'
-          - php-version: '7.4'
-            symfony-version: 'latest'
           - php-version: '8.0'
             symfony-version: '^3.4'
           - php-version: '8.0'


### PR DESCRIPTION
## Goal

Symfony 6 requires PHP 8 so we can't run the latest version of Symfony with PHP 7.4 on CI anymore