### PR TITLE
Update CI for PHP 8.1

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -78,6 +78,8 @@ jobs:
             symfony-version: '^4.4'
           - php-version: '8.1'
             symfony-version: '^5.0'
+          - php-version: '8.1'
+            symfony-version: 'latest'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -76,10 +76,8 @@ jobs:
             symfony-version: 'latest'
           - php-version: '8.1'
             symfony-version: '^4.4'
-            composer-flags: '--ignore-platform-req php'
           - php-version: '8.1'
             symfony-version: '^5.0'
-            composer-flags: '--ignore-platform-req php'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -72,8 +72,6 @@ jobs:
             symfony-version: '^4.4'
           - php-version: '8.0'
             symfony-version: '^5.0'
-          - php-version: '8.0'
-            symfony-version: 'latest'
           - php-version: '8.1'
             symfony-version: '^4.4'
           - php-version: '8.1'


### PR DESCRIPTION
## Goal

Removes the `ignore-platform-req` flag on PHP 8.1 as it's no longer necessary and tests against the latest Symfony version on PHP 8.1 instead of PHP 8.0