### PR TITLE
Add return type to docblock of `BugsnagListener::getSubscribedEvents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Prevent a deprecation from `BugsnagListener::getSubscribedEvents`
+  [#138](https://github.com/bugsnag/bugsnag-symfony/pull/138)
+
 ## 1.10.0 (2021-06-30)
 
 ### Enhancements

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -248,6 +248,9 @@ class BugsnagListener implements EventSubscriberInterface
             || $throwable instanceof OutOfMemoryException;
     }
 
+    /**
+     * @return array<string, array{string, int}>
+     */
     public static function getSubscribedEvents()
     {
         $listeners = [


### PR DESCRIPTION
## Goal

This prevents a deprecation from Symfony's DebugClassLoader — essentially, because Symfony's `EventSubscriberInterface` [has an `@return` in its docblock](https://github.com/symfony/symfony/blob/80f4e7628511fafb38c5b2e4fbd85e264c247793/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php#L46), we also need one