### PR TITLE
Fixed invalid phpDoc

### DIFF
--- a/EventListener/BugsnagShutdown.php
+++ b/EventListener/BugsnagShutdown.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 class BugsnagShutdown implements EventSubscriberInterface, ShutdownStrategyInterface
 {
     /**
-     * @var Client
+     * @var Client|null
      */
     private $client;
 

--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -94,7 +94,7 @@ class SymfonyRequest implements RequestInterface
      *
      * This is based on Laravel's input source generation.
      *
-     * @return \Symfony\Component\HttpFoundation\ParameterBag
+     * @return array
      */
     protected function getInput()
     {

--- a/Request/SymfonyResolver.php
+++ b/Request/SymfonyResolver.php
@@ -18,7 +18,7 @@ class SymfonyResolver implements ResolverInterface
     /**
      * Set the current request.
      *
-     * @param \Symfony\Component\HttpFoundation\Request
+     * @param \Symfony\Component\HttpFoundation\Request $request
      *
      * @return void
      */


### PR DESCRIPTION
## Goal

These fixes allow to prevent errors reported by static analysis tools like _psalm_ or _phpstan_ under certain conditions.

I have a use case where I need to extend the class SymfonyRequest, and override the method `getInput`, but psalm complains about the return type being incompatible with `Symfony\Component\HttpFoundation\ParameterBag` from the parent method, even though this method returns an array.