### PR TITLE
Fix failing CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,4 @@
 /features export-ignore
 /Gemfile export-ignore
 /Gemfile.lock export-ignore
+/vendor export-ignore

--- a/features/fixtures/symfony-2/Dockerfile
+++ b/features/fixtures/symfony-2/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
   unzip
 
 COPY . .
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 RUN sh setup-github-token.sh
 RUN php setup-bugsnag-config.php

--- a/features/fixtures/symfony-2/composer.json
+++ b/features/fixtures/symfony-2/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "bugsnag/bugsnag-symfony": "dev-master as 99.99.99",
+        "bugsnag/bugsnag-symfony": "dev-main as 99.99.99",
         "doctrine/doctrine-bundle": "~1.4",
         "doctrine/orm": "^2.4.8",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/features/fixtures/symfony-4/Dockerfile
+++ b/features/fixtures/symfony-4/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
   unzip
 
 COPY . .
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 RUN sh setup-github-token.sh
 RUN php setup-bugsnag-config.php

--- a/features/fixtures/symfony-4/composer.json
+++ b/features/fixtures/symfony-4/composer.json
@@ -14,7 +14,7 @@
         "php": ">=7.1.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "bugsnag/bugsnag-symfony": "dev-master as 99.99.99",
+        "bugsnag/bugsnag-symfony": "dev-main as 99.99.99",
         "composer/package-versions-deprecated": "1.11.99.4",
         "doctrine/annotations": "^1.0",
         "doctrine/doctrine-bundle": "^2.4",

--- a/features/fixtures/symfony-5/Dockerfile
+++ b/features/fixtures/symfony-5/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
   unzip
 
 COPY . .
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 RUN sh setup-github-token.sh
 RUN php setup-bugsnag-config.php

--- a/features/fixtures/symfony-5/composer.json
+++ b/features/fixtures/symfony-5/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.2.5",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "bugsnag/bugsnag-symfony": "dev-master as 99.99.99",
+        "bugsnag/bugsnag-symfony": "dev-main as 99.99.99",
         "composer/package-versions-deprecated": "1.11.99.2",
         "doctrine/annotations": "^1.0",
         "doctrine/doctrine-bundle": "^2.4",


### PR DESCRIPTION
## Goal

CI has been failing recently because the Maze Runner fixtures no longer build successfully:

> Unable to find a compatible set of packages based on your non-dev requirements alone.
> Your requirements can be resolved successfully when require-dev packages are present.
> You may need to move packages from require-dev or some of their dependencies to require.
> 
>   Problem 1
>     - Root composer.json requires bugsnag/bugsnag-symfony dev-master as 99.99.99, found bugsnag/bugsnag-symfony[dev-main] but it does not match the constraint. Perhaps dev-master was renamed to dev-main?

This error seems to be caused by Composer no longer accepting `dev-master` in a package installed from a directory, which is how we install `bugsnag-symfony` in the test fixtures

This seems to be caused by https://github.com/composer/composer/pull/10372, though that PR adds an alias for `dev-master` so I'm not 100% sure

Finally, there was an unrelated error caused by cucumber/gherkin failing to parse something from its own test suite:

> features/fixtures/symfony-4/bugsnag-symfony/vendor/bundle/ruby/3.0.0/gems/gherkin-5.1.0/spec/gherkin/stream/test_fr.feature: Parser errors:
15
> expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Fonctionnalité: Bonjour'
16
> expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Scénario: Monde'
17
> expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Soit une étape' (Cucumber::Core::Gherkin::ParseError)
18
> https://github.com/bugsnag/bugsnag-symfony/runs/4804287510?check_suite_focus=true#step:5:14

I'm not sure this started happening when we have a lock file for Maze Runner & its dependencies, but I've also fixed this