### PR TITLE
Call `getUserIdentifier` instead of `getUsername` on Symfony 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Call `getUserIdentifier` instead of `getUsername` on Symfony 6
+  [#145](https://github.com/bugsnag/bugsnag-symfony/pull/145)
+
 ## 1.11.0 (2021-12-13)
 
 ### Enhancements

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -395,7 +395,15 @@ class ClientFactory
                     return ['id' => $user->getUserIdentifier()];
                 }
 
-                return ['id' => $user->getUsername()];
+                // Symfony 5.4 and below use 'getUsername' ('getUserIdentifier'
+                // wasn't added to the interface until Symfony 6.0 for BC)
+                if (method_exists(UserInterface::class, 'getUsername')) {
+                    return ['id' => $user->getUsername()];
+                }
+
+                // if neither method exists then we don't know how to deal with
+                // this version of Symfony's UserInterface, so can't get an ID
+                return;
             }
 
             return ['id' => (string) $user];

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -389,6 +389,12 @@ class ClientFactory
             $user = $token->getUser();
 
             if ($user instanceof UserInterface) {
+                // Symfony 5.3 introduced 'getUserIdentifier' to replace 'getUsername'
+                // Symfony 6.0 removed 'getUsername'
+                if (method_exists(UserInterface::class, 'getUserIdentifier')) {
+                    return ['id' => $user->getUserIdentifier()];
+                }
+
                 return ['id' => $user->getUsername()];
             }
 

--- a/features/fixtures/symfony-4/config/packages/security.yaml
+++ b/features/fixtures/symfony-4/config/packages/security.yaml
@@ -1,20 +1,20 @@
 security:
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
-        users_in_memory: { memory: null }
+        # used to reload user from session & other features (e.g. switch_user)
+        app_user_provider:
+            id: App\Security\UserProvider
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             anonymous: lazy
-            provider: users_in_memory
+            provider: app_user_provider
 
-            # activate different ways to authenticate
-            # https://symfony.com/doc/current/security.html#firewalls-authentication
-
-            # https://symfony.com/doc/current/security/impersonating_user.html
-            # switch_user: true
+            guard:
+                authenticators:
+                    - App\Security\QueryStringAuthenticator
 
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used

--- a/features/fixtures/symfony-4/src/Security/QueryStringAuthenticator.php
+++ b/features/fixtures/symfony-4/src/Security/QueryStringAuthenticator.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+
+class QueryStringAuthenticator extends AbstractGuardAuthenticator
+{
+    /**
+     * Called on every request to decide if this authenticator should be
+     * used for the request. Returning `false` will cause this authenticator
+     * to be skipped.
+     */
+    public function supports(Request $request): bool
+    {
+        return $request->query->has('name');
+    }
+
+    /**
+     * Called on every request. Return whatever credentials you want to
+     * be passed to getUser() as $credentials.
+     */
+    public function getCredentials(Request $request)
+    {
+        return $request->query->get('name');
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider): ?UserInterface
+    {
+        if (null === $credentials) {
+            return null;
+        }
+
+        return $userProvider->loadUserByUsername($credentials);
+    }
+
+    public function checkCredentials($credentials, UserInterface $user): bool
+    {
+        return true;
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey): ?Response
+    {
+        // on success, let the request continue
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        $data = [
+            'message' => strtr($exception->getMessageKey(), $exception->getMessageData())
+        ];
+
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * Called when authentication is needed, but it's not sent
+     */
+    public function start(Request $request, AuthenticationException $authException = null): Response
+    {
+        $data = [
+            'message' => 'Authentication Required'
+        ];
+
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
+    }
+
+    public function supportsRememberMe(): bool
+    {
+        return false;
+    }
+}

--- a/features/fixtures/symfony-4/src/Security/User.php
+++ b/features/fixtures/symfony-4/src/Security/User.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class User implements UserInterface
+{
+    private string $id;
+
+    private array $roles = [];
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * A visual identifier that represents this user.
+     *
+     * @see UserInterface
+     */
+    public function getUsername(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+
+        // guarantee every user at least has ROLE_USER
+        $roles[] = 'ROLE_USER';
+
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
+    /**
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
+     *
+     * @see UserInterface
+     */
+    public function getPassword(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * This method can be removed in Symfony 6.0 - is not needed for apps that do not check user passwords.
+     *
+     * @see UserInterface
+     */
+    public function getSalt(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function eraseCredentials()
+    {
+        // If you store any temporary, sensitive data on the user, clear it here
+    }
+}

--- a/features/fixtures/symfony-4/src/Security/UserProvider.php
+++ b/features/fixtures/symfony-4/src/Security/UserProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
+{
+    /**
+     * Symfony calls this method if you use features like switch_user
+     * or remember_me.
+     *
+     * If you're not using these features, you do not need to implement
+     * this method.
+     *
+     * @throws UsernameNotFoundException if the user is not found
+     */
+    public function loadUserByUsername($username): UserInterface
+    {
+        switch ($username) {
+            case 'abc':
+                return new User('abc-123');
+
+            case 'xyz':
+                return new User('xyz-789');
+
+            default:
+                throw new UsernameNotFoundException("No user exists with the name '{$username}'");
+        }
+    }
+
+    /**
+     * Refreshes the user after being reloaded from the session.
+     *
+     * When a user is logged in, at the beginning of each request, the
+     * User object is loaded from the session and then this method is
+     * called. Your job is to make sure the user's data is still fresh by,
+     * for example, re-querying for fresh User data.
+     *
+     * If your firewall is "stateless: true" (for a pure API), this
+     * method is not called.
+     */
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        if (!$user instanceof User) {
+            throw new UnsupportedUserException(sprintf('Invalid user class "%s".', get_class($user)));
+        }
+
+        // Return a User object after making sure its data is "fresh".
+        // Or throw a UsernameNotFoundException if the user no longer exists.
+        return $user;
+    }
+
+    /**
+     * Tells Symfony to use this provider for this User class.
+     */
+    public function supportsClass($class): bool
+    {
+        return User::class === $class || is_subclass_of($class, User::class);
+    }
+
+    /**
+     * Upgrades the hashed password of a user, typically for using a better hash algorithm.
+     */
+    public function upgradePassword(UserInterface $user, string $newHashedPassword): void
+    {
+    }
+}

--- a/features/fixtures/symfony-6/config/packages/security.yaml
+++ b/features/fixtures/symfony-6/config/packages/security.yaml
@@ -5,20 +5,19 @@ security:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
-        users_in_memory: { memory: null }
+        # used to reload user from session & other features (e.g. switch_user)
+        app_user_provider:
+            id: App\Security\UserProvider
     firewalls:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
 
-            # activate different ways to authenticate
-            # https://symfony.com/doc/current/security.html#the-firewall
-
-            # https://symfony.com/doc/current/security/impersonating_user.html
-            # switch_user: true
+            custom_authenticators:
+                - App\Security\QueryStringAuthenticator
 
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used

--- a/features/fixtures/symfony-6/src/Security/QueryStringAuthenticator.php
+++ b/features/fixtures/symfony-6/src/Security/QueryStringAuthenticator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+class QueryStringAuthenticator extends AbstractAuthenticator
+{
+    /**
+     * Called on every request to decide if this authenticator should be
+     * used for the request. Returning `false` will cause this authenticator
+     * to be skipped.
+     */
+    public function supports(Request $request): ?bool
+    {
+        return $request->query->has('name');
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $name = $request->query->get('name');
+
+        if ($name === null) {
+            throw new CustomUserMessageAuthenticationException('No name provided');
+        }
+
+        return new SelfValidatingPassport(new UserBadge($name));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        // on success, let the request continue
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        $data = [
+            'message' => strtr($exception->getMessageKey(), $exception->getMessageData()),
+        ];
+
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/features/fixtures/symfony-6/src/Security/User.php
+++ b/features/fixtures/symfony-6/src/Security/User.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class User implements UserInterface
+{
+    private string $id;
+
+    private array $roles = [];
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * A visual identifier that represents this user.
+     *
+     * @see UserInterface
+     */
+    public function getUserIdentifier(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+
+        // guarantee every user at least has ROLE_USER
+        $roles[] = 'ROLE_USER';
+
+        return array_unique($roles);
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
+    /**
+     * @see UserInterface
+     */
+    public function eraseCredentials()
+    {
+        // If you store any temporary, sensitive data on the user, clear it here
+    }
+}

--- a/features/fixtures/symfony-6/src/Security/UserProvider.php
+++ b/features/fixtures/symfony-6/src/Security/UserProvider.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
+{
+    /**
+     * Symfony calls this method if you use features like switch_user
+     * or remember_me.
+     *
+     * If you're not using these features, you do not need to implement
+     * this method.
+     *
+     * @throws UserNotFoundException if the user is not found
+     */
+    public function loadUserByIdentifier($identifier): UserInterface
+    {
+        switch ($identifier) {
+            case 'abc':
+                return new User('abc-123');
+
+            case 'xyz':
+                return new User('xyz-789');
+
+            default:
+                throw new UserNotFoundException("No user exists with ID '{$identifier}'");
+        }
+    }
+
+    /**
+     * @deprecated since Symfony 5.3, loadUserByIdentifier() is used instead
+     */
+    public function loadUserByUsername($username): UserInterface
+    {
+        return $this->loadUserByIdentifier($username);
+    }
+
+    /**
+     * Refreshes the user after being reloaded from the session.
+     *
+     * When a user is logged in, at the beginning of each request, the
+     * User object is loaded from the session and then this method is
+     * called. Your job is to make sure the user's data is still fresh by,
+     * for example, re-querying for fresh User data.
+     *
+     * If your firewall is "stateless: true" (for a pure API), this
+     * method is not called.
+     */
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        if (!$user instanceof User) {
+            throw new UnsupportedUserException(sprintf('Invalid user class "%s".', get_class($user)));
+        }
+
+        // Return a User object after making sure its data is "fresh".
+        // Or throw a UsernameNotFoundException if the user no longer exists.
+        return $user;
+    }
+
+    /**
+     * Tells Symfony to use this provider for this User class.
+     */
+    public function supportsClass($class): bool
+    {
+        return User::class === $class || is_subclass_of($class, User::class);
+    }
+
+    /**
+     * Upgrades the hashed password of a user, typically for using a better hash algorithm.
+     */
+    public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
+    {
+    }
+}

--- a/features/user-detection.feature
+++ b/features/user-detection.feature
@@ -2,7 +2,6 @@ Feature: The current user ID should be detected automatically
 
 @not_symfony_2
 @not_symfony_5
-@not_symfony_6
 Scenario: The user ID of 'abc' should be detected when they are signed in
   Given I start the symfony fixture
   When I navigate to the route "/unhandled/controller/exception?name=abc"
@@ -22,7 +21,6 @@ Scenario: The user ID of 'abc' should be detected when they are signed in
 
 @not_symfony_2
 @not_symfony_5
-@not_symfony_6
 Scenario: The user ID of 'xyz' should be detected when they are signed in
   Given I start the symfony fixture
   When I navigate to the route "/unhandled/controller/exception?name=xyz"

--- a/features/user-detection.feature
+++ b/features/user-detection.feature
@@ -1,0 +1,41 @@
+Feature: The current user ID should be detected automatically
+
+@not_symfony_2
+@not_symfony_5
+@not_symfony_6
+Scenario: The user ID of 'abc' should be detected when they are signed in
+  Given I start the symfony fixture
+  When I navigate to the route "/unhandled/controller/exception?name=abc"
+  Then I wait to receive an error
+  And the error is valid for the error reporting API version "4.0" for the "Bugsnag Symfony" notifier
+  And the event "user.id" equals "abc-123"
+  And the exception "errorClass" equals "RuntimeException"
+  And the exception "message" equals "Crashing exception!"
+  And the event "metaData.request.httpMethod" equals "GET"
+  And the event "metaData.request.url" ends with "/unhandled/controller/exception?name=abc"
+  And the event "app.type" equals "HTTP"
+  And the event "context" equals "GET /unhandled/controller/exception"
+  And the event "severity" equals "error"
+  And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Symfony"
+
+@not_symfony_2
+@not_symfony_5
+@not_symfony_6
+Scenario: The user ID of 'xyz' should be detected when they are signed in
+  Given I start the symfony fixture
+  When I navigate to the route "/unhandled/controller/exception?name=xyz"
+  Then I wait to receive an error
+  And the error is valid for the error reporting API version "4.0" for the "Bugsnag Symfony" notifier
+  And the event "user.id" equals "xyz-789"
+  And the exception "errorClass" equals "RuntimeException"
+  And the exception "message" equals "Crashing exception!"
+  And the event "metaData.request.httpMethod" equals "GET"
+  And the event "metaData.request.url" ends with "/unhandled/controller/exception?name=xyz"
+  And the event "app.type" equals "HTTP"
+  And the event "context" equals "GET /unhandled/controller/exception"
+  And the event "severity" equals "error"
+  And the event "unhandled" is true
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Symfony"


### PR DESCRIPTION
## Goal

We automatically detect the logged in user's ID, which currently uses `getUsername` to fetch an identifier:

https://github.com/bugsnag/bugsnag-symfony/blob/d094e0e247bfedcd8877f4a864105ec8cede26b8/DependencyInjection/ClientFactory.php#L391-L393

Symfony 5.3 deprecated `getUsername` and introduced `getUserIdentifier` to replace it. Symfony 6.0 has subsequently removed `getUsername`, leaving only `getUserIdentifier`. This causes a crash as we're calling a method that may not exist (older code bases may still implement `getUsername` in addition to `getUserIdentifier`)

See https://github.com/bugsnag/bugsnag-symfony/issues/141

## Testing

I've added a Maze Runner test for our user detection logic on Symfony 4 and 6. This covers both the `getUsername` branch, as well as the `getUserIdentifier` branch

I'll add the same test setup for Symfony 2 & 5 separately, to avoid making this PR too huge