### PR TITLE
fix: checks haystack is null before using stripos()

### DIFF
--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -101,9 +101,11 @@ class SymfonyRequest implements RequestInterface
         $type = $this->request->headers->get('CONTENT_TYPE');
 
         // If it's json, decode it
-        if (stripos($type, '/json') !== false || stripos($type, '+json') !== false) {
-            if (is_array($parsed = json_decode($this->request->getContent(), true))) {
-                return $parsed;
+        if (!is_null($type)) {
+            if (stripos($type, '/json') !== false || stripos($type, '+json') !== false) {
+                if (is_array($parsed = json_decode($this->request->getContent(), true))) {
+                    return $parsed;
+                }
             }
         }
 


### PR DESCRIPTION
I got a deprecated error when using `bugsnag-symfony` with PHP 8.1 : 

```
stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated in vendor/bugsnag/bugsnag-symfony/Request/SymfonyRequest.php line 104
```

This is my first PR, so please tell me if something is not right.

## Goal

Make `bugsnag-symfony` compatible with PHP 8.1.

## Changeset

It checks that `$haystack` is not null before using `stripos()`

## Testing

I ran phpunit tests