### PR TITLE
Fix PHP 8.1 deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Fix PHP 8.1 deprecation from `stripos` in `Request::getInput`
+  [phillylovepark](https://github.com/phillylovepark)
+  [#147](https://github.com/bugsnag/bugsnag-symfony/pull/147)
+  [#149](https://github.com/bugsnag/bugsnag-symfony/pull/149)
+
 ## 1.11.1 (2022-01-19)
 
 ### Bug Fixes

--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -101,9 +101,11 @@ class SymfonyRequest implements RequestInterface
         $type = $this->request->headers->get('CONTENT_TYPE');
 
         // If it's json, decode it
-        if (stripos($type, '/json') !== false || stripos($type, '+json') !== false) {
-            if (is_array($parsed = json_decode($this->request->getContent(), true))) {
-                return $parsed;
+        if (!is_null($type)) {
+            if (stripos($type, '/json') !== false || stripos($type, '+json') !== false) {
+                if (is_array($parsed = json_decode($this->request->getContent(), true))) {
+                    return $parsed;
+                }
             }
         }
 

--- a/Request/SymfonyRequest.php
+++ b/Request/SymfonyRequest.php
@@ -98,18 +98,14 @@ class SymfonyRequest implements RequestInterface
      */
     protected function getInput()
     {
-        $type = $this->request->headers->get('CONTENT_TYPE');
+        if ($this->isJsonContentType($this->request->headers->get('CONTENT_TYPE'))) {
+            $parsed = json_decode($this->request->getContent(), true);
 
-        // If it's json, decode it
-        if (!is_null($type)) {
-            if (stripos($type, '/json') !== false || stripos($type, '+json') !== false) {
-                if (is_array($parsed = json_decode($this->request->getContent(), true))) {
-                    return $parsed;
-                }
+            if (is_array($parsed)) {
+                return $parsed;
             }
         }
 
-        // Yes, we really do want request->request
         return $this->request->request->all();
     }
 
@@ -131,5 +127,20 @@ class SymfonyRequest implements RequestInterface
     public function getUserId()
     {
         return $this->request->getClientIp();
+    }
+
+    /**
+     * @param mixed $contentType
+     *
+     * @return bool
+     */
+    private function isJsonContentType($contentType)
+    {
+        if (is_string($contentType)) {
+            return stripos($contentType, '/json') !== false
+                || stripos($contentType, '+json') !== false;
+        }
+
+        return false;
     }
 }

--- a/Tests/Request/SymfonyRequestTest.php
+++ b/Tests/Request/SymfonyRequestTest.php
@@ -95,4 +95,268 @@ class SymfonyRequestTest extends TestCase
 
         $this->assertSame(['foobar' => 'baz'], $session);
     }
+
+    public function testItIsARequest()
+    {
+        $request = new SymfonyRequest(new Request());
+
+        $this->assertTrue($request->isRequest());
+    }
+
+    public function testItReturnsCookieData()
+    {
+        $cookies = ['a_cookie' => 'a value for the first cookie', 'another_cookie' => 'another value'];
+
+        $symfonyRequest = new Request([], [], [], $cookies);
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $this->assertSame($cookies, $request->getCookies());
+    }
+
+    public function testItReturnsCookieDataWhenThereAreNoCookies()
+    {
+        $symfonyRequest = new Request();
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $this->assertSame([], $request->getCookies());
+    }
+
+    public function testItReturnsMetadataWhenThereIsNoRequestData()
+    {
+        $symfonyRequest = new Request();
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $expected = [
+            'request' => [
+                'url' => 'http://:/',
+                'httpMethod' => 'GET',
+                'params' => [],
+                'clientIp' => null,
+            ],
+        ];
+
+        $this->assertSame($expected, $request->getMetaData());
+    }
+
+    public function testItReturnsMetadataWhenThereIsSomeRequestData()
+    {
+        $symfonyRequest = new Request(
+            ['x' => 'y'],
+            [],
+            [],
+            [],
+            [],
+            [
+                'HTTPS' => 'on',
+                'PHP_SELF' => '/index.php',
+                'QUERY_STRING' => 'x=y',
+                'REMOTE_ADDR' => '1.2.3.4',
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/abc',
+                'SCRIPT_NAME' => '/index.php',
+                'SERVER_NAME' => 'www.example.com',
+                'SERVER_PORT' => '1234',
+            ]
+        );
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $expected = [
+            'request' => [
+                'url' => 'https://www.example.com:1234/abc?x=y',
+                'httpMethod' => 'GET',
+                'params' => ['x' => 'y'],
+                'clientIp' => '1.2.3.4',
+            ],
+        ];
+
+        $this->assertSame($expected, $request->getMetaData());
+    }
+
+    public function testItIncludesHeadersJsonAndUserAgentInMetadataWhenPresent()
+    {
+        $symfonyRequest = new Request(
+            ['x' => 'y'],
+            [],
+            [],
+            [],
+            [],
+            [
+                'HTTPS' => 'on',
+                'HTTP_ACCEPT' => 'text/html',
+                'HTTP_ACCEPT_LANGUAGE' => 'en',
+                'HTTP_ACCEPT_ENCODING' => 'gzip',
+                'HTTP_CONTENT_TYPE' => 'application/json',
+                'HTTP_HOST' => 'www.example.com:1234',
+                'HTTP_USER_AGENT' => 'bugsnag',
+                'PHP_SELF' => '/index.php',
+                'QUERY_STRING' => 'x=y',
+                'REMOTE_ADDR' => '1.2.3.4',
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/abc',
+                'SCRIPT_NAME' => '/index.php',
+                'SERVER_NAME' => 'www.example.com',
+                'SERVER_PORT' => '1234',
+            ],
+            '{ "a": "b" }'
+        );
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $expected = [
+            'request' => [
+                'url' => 'https://www.example.com:1234/abc?x=y',
+                'httpMethod' => 'GET',
+                'params' => ['a' => 'b', 'x' => 'y'],
+                'clientIp' => '1.2.3.4',
+                'userAgent' => 'bugsnag',
+                'headers' => [
+                    'accept' => ['text/html'],
+                    'accept-language' => ['en'],
+                    'accept-encoding' => ['gzip'],
+                    'content-type' => ['application/json'],
+                    'host' => ['www.example.com:1234'],
+                    'user-agent' => ['bugsnag'],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $request->getMetaData());
+    }
+
+    /**
+     * @dataProvider jsonContentTypeProvider
+     */
+    public function testItDecodesJson($contentType)
+    {
+        $symfonyRequest = new Request(
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['HTTP_CONTENT_TYPE' => $contentType],
+            '{ "a": "b", "c": "d", "x": { "y": 123 } }'
+        );
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $expected = ['a' => 'b', 'c' => 'd', 'x' => ['y' => 123]];
+        $metadata = $request->getMetaData();
+
+        $this->assertSame($expected, $metadata['request']['params']);
+        $this->assertSame($contentType, $metadata['request']['headers']['content-type'][0]);
+    }
+
+    public function jsonContentTypeProvider()
+    {
+        return [
+            'content type: "application/json"' => ['application/json'],
+            'content type: "/JsOn"' => ['/JsOn'],
+            'content type: "TEXT/JSON"' => ['TEXT/JSON'],
+            'content type: "application/stuff+json"' => ['application/stuff+json'],
+            'content type: "+jSoN"' => ['+jSoN'],
+        ];
+    }
+
+    /**
+     * @dataProvider nonJsonContentTypeProvider
+     */
+    public function testItDoesNotDecodeNonJsonContentTypes($contentType)
+    {
+        $symfonyRequest = new Request(
+            [],
+            [],
+            [],
+            [],
+            [],
+            ['HTTP_CONTENT_TYPE' => $contentType],
+            '{ "a": "b", "c": "d", "x": { "y": 123 } }'
+        );
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $metadata = $request->getMetaData();
+
+        $this->assertEmpty($metadata['request']['params']);
+        $this->assertSame($contentType, $metadata['request']['headers']['content-type'][0]);
+    }
+
+    public function nonJsonContentTypeProvider()
+    {
+        return [
+            'content type: "application/xml"' => ['application/xml'],
+            'content type: "/xml"' => ['/xml'],
+            'content type: "text/xml"' => ['text/xml'],
+            'content type: "application/stuff+yaml"' => ['application/stuff+yaml'],
+            'content type: "+yaml"' => ['+yaml'],
+        ];
+    }
+
+    public function testItDoesNotDecodeTheBodyWhenThereIsNoContentType()
+    {
+        $symfonyRequest = new Request();
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $metadata = $request->getMetaData();
+
+        $this->assertEmpty($metadata['request']['params']);
+    }
+
+    public function testItReturnsTheRequestContext()
+    {
+        $symfonyRequest = new Request([], [], [], [], [], [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/some/route',
+        ]);
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $this->assertSame('GET /some/route', $request->getContext());
+    }
+
+    public function testItReturnsTheRequestContextForAPostRequest()
+    {
+        $symfonyRequest = new Request([], [], [], [], [], [
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => '/some/other/route',
+        ]);
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $this->assertSame('POST /some/other/route', $request->getContext());
+    }
+
+    public function testItReturnsTheRequestContextWhenServerInformationIsMissing()
+    {
+        $symfonyRequest = new Request();
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $this->assertSame('GET /', $request->getContext());
+    }
+
+    public function testItReturnsTheUserId()
+    {
+        $symfonyRequest = new Request([], [], [], [], [], [
+            'REMOTE_ADDR' => '1.2.3.4',
+        ]);
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $this->assertSame('1.2.3.4', $request->getUserId());
+    }
+
+    public function testItReturnsTheUserIdWhenServerInformationIsMissing()
+    {
+        $symfonyRequest = new Request();
+
+        $request = new SymfonyRequest($symfonyRequest);
+
+        $this->assertNull($request->getUserId());
+    }
 }


### PR DESCRIPTION
## Goal

This is https://github.com/bugsnag/bugsnag-symfony/pull/147 rebased onto next, with some unit tests and a changelog entry. I've also attempted to simplify the nested conditionals that were getting somewhat complicated

I've added tests for the SymfonyRequest class, because there were no tests for it before now (other than indirectly in the Maze Runner suite). These fail when run with PHP 8.1 on `next`, proving the deprecation is fixed by this PR ([e.g. see this failing run](https://github.com/bugsnag/bugsnag-symfony/runs/5009710002?check_suite_focus=true))