### PR TITLE
Fix CI failing due to changes to composer

### DIFF
--- a/features/fixtures/symfony-4/composer.json
+++ b/features/fixtures/symfony-4/composer.json
@@ -63,7 +63,10 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/features/fixtures/symfony-5/composer.json
+++ b/features/fixtures/symfony-5/composer.json
@@ -69,7 +69,11 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true,
+            "symfony/runtime": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Goal

Similar to https://github.com/bugsnag/bugsnag-laravel/pull/492, we need to allow some composer plugins in our Symfony 4 & 5 test fixtures to fix CI (the Symfony 6 fixture already allows these plugins)