### PR TITLE
Add `max_breadcrumbs` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add `max_breadcrumbs` config option for configuring the maximum number of breadcrumbs to attach to a report
+  [#158](https://github.com/bugsnag/bugsnag-symfony/pull/158)
+
 ## 1.12.0 (2022-05-20)
 
 ### Enhancements

--- a/DependencyInjection/ClientFactory.php
+++ b/DependencyInjection/ClientFactory.php
@@ -222,6 +222,13 @@ class ClientFactory
     private $featureFlags;
 
     /**
+     * The maximum number of breadcrumbs that are allowed to be stored.
+     *
+     * @var int|null
+     */
+    private $maxBreadcrumbs;
+
+    /**
      * @param SymfonyResolver                    $resolver
      * @param TokenStorageInterface|null         $tokens
      * @param AuthorizationCheckerInterface|null $checker
@@ -249,6 +256,7 @@ class ClientFactory
      * @param array                              $discardClasses
      * @param string[]                           $redactedKeys
      * @param array[]                            $featureFlags
+     * @param int|null                           $maxBreadcrumbs
      *
      * @return void
      */
@@ -279,7 +287,8 @@ class ClientFactory
         $memoryLimitIncrease = false,
         array $discardClasses = [],
         array $redactedKeys = [],
-        array $featureFlags = []
+        array $featureFlags = [],
+        $maxBreadcrumbs = null
     ) {
         $this->resolver = $resolver;
         $this->tokens = $tokens;
@@ -310,6 +319,7 @@ class ClientFactory
         $this->discardClasses = $discardClasses;
         $this->redactedKeys = $redactedKeys;
         $this->featureFlags = $featureFlags;
+        $this->maxBreadcrumbs = $maxBreadcrumbs;
     }
 
     /**
@@ -389,6 +399,10 @@ class ClientFactory
             }, $this->featureFlags);
 
             $client->addFeatureFlags($featureFlags);
+        }
+
+        if ($this->maxBreadcrumbs !== null) {
+            $client->setMaxBreadcrumbs($this->maxBreadcrumbs);
         }
 
         return $client;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -134,6 +134,8 @@ class Configuration implements ConfigurationInterface
                     ->treatNullLike([])
                     ->defaultValue([])
                 ->end()
+                ->scalarNode('max_breadcrumbs')
+                    ->defaultNull()
             ->end();
 
         return $treeBuilder;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -32,6 +32,7 @@ services:
           - '%bugsnag.discard_classes%'
           - '%bugsnag.redacted_keys%'
           - '%bugsnag.feature_flags%'
+          - '%bugsnag.max_breadcrumbs%'
 
     bugsnag:
         class: '%bugsnag.client%'

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -331,6 +331,22 @@ final class ClientFactoryTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testMaxBreadcrumbsIsSetCorrectly()
+    {
+        $maxBreadcrumbs = 100;
+
+        $client = $this->createClient([
+            'maxBreadcrumbs' => $maxBreadcrumbs,
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $actual = $client->getMaxBreadcrumbs();
+
+        $this->assertSame($maxBreadcrumbs, $actual);
+    }
+
     /**
      * Get the value of the given property on the given object.
      *
@@ -423,6 +439,7 @@ final class ClientFactoryTest extends TestCase
             'discardClasses' => [],
             'redactedKeys' => [],
             'featureFlags' => [],
+            'maxBreadcrumbs' => null,
         ];
     }
 }

--- a/Tests/DependencyInjection/ClientFactoryTest.php
+++ b/Tests/DependencyInjection/ClientFactoryTest.php
@@ -422,6 +422,7 @@ final class ClientFactoryTest extends TestCase
             'memoryLimitIncrease' => false,
             'discardClasses' => [],
             'redactedKeys' => [],
+            'featureFlags' => [],
         ];
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -41,6 +41,7 @@ final class ConfigurationTest extends TestCase
         'discard_classes' => [],
         'redacted_keys' => [],
         'feature_flags' => [],
+        'max_breadcrumbs' => null,
     ];
 
     /**
@@ -108,6 +109,7 @@ final class ConfigurationTest extends TestCase
                         ['name' => 'flag1'],
                         ['name' => 'flag2', 'variant' => 'var1'],
                     ],
+                    'max_breadcrumbs' => 100,
                 ],
                 $this->buildExpectedConfiguration($fullConfig),
             ],


### PR DESCRIPTION
## Goal

Add `max_breadcrumbs` config option for configuring the maximum number of breadcrumbs to attach to a report: https://docs.bugsnag.com/platforms/php/other/configuration-options/#max-breadcrumbs