### PR TITLE
SUP-2616 / Bump Symfony 5 example to supported PHP version

### DIFF
--- a/example/symfony50/composer.json
+++ b/example/symfony50/composer.json
@@ -3,7 +3,7 @@
     "license": "proprietary",
     "minimum-stability": "dev",
     "require": {
-        "php": "^8.1.0",
+        "php": ">=7.2.5",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "bugsnag/bugsnag-symfony": "^1.5.0",

--- a/example/symfony50/composer.json
+++ b/example/symfony50/composer.json
@@ -3,7 +3,7 @@
     "license": "proprietary",
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.2.9",
+        "php": "^8.1.0",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "bugsnag/bugsnag-symfony": "^1.5.0",


### PR DESCRIPTION
Our Symfony example app currently uses a v7 version of PHP, which is now past EOL. We should bump it to use a supported version as per https://www.php.net/supported-versions.php - minimum 8.1 looks sensible.