### PR TITLE
Update lastversion version

### DIFF
--- a/.ci/require-symfony.sh
+++ b/.ci/require-symfony.sh
@@ -29,7 +29,7 @@ SYMFONY_VERSION=$1
 if [ "$SYMFONY_VERSION" = "latest" ]; then
     if ! [ "$(command -v lastversion)" ]; then
         # Install "lastversion" if it's not already installed
-        pip install lastversion==v1.6.0
+        pip install lastversion==v2.4.15
     fi
 
     composer require "symfony/config:$(lastversion symfony/config --pre)" --no-update


### PR DESCRIPTION
## Goal

The `lastversion` tool has been [breaking CI over the weekend](https://github.com/bugsnag/bugsnag-symfony/actions/runs/4920895591/jobs/8796273139) because of an incompatible update to one of its dependencies. This PR updates to the latest version [so it works again](https://github.com/bugsnag/bugsnag-symfony/actions/runs/4923943784/jobs/8796381269)