### PR TITLE
Update symfony40 example's `bugsnag/bugsnag-symfony` version

### DIFF
--- a/example/symfony40/composer.json
+++ b/example/symfony40/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-iconv": "*",
-        "bugsnag/bugsnag-symfony": "dev-symfony-4-fixes",
+        "bugsnag/bugsnag-symfony": "^1.5.0",
         "sensio/framework-extra-bundle": "^5.1",
         "symfony/console": "^4.0",
         "symfony/flex": "^1.0",


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Running `composer install` in the `symfony40` example returns the following error:

`Root composer.json requires bugsnag/bugsnag-symfony dev-symfony-4-fixes, found bugsnag/bugsnag-symfony[dev-fix-lastversion-version, dev-next, dev-master, v1.0.0, ..., v1.13.0] but it does not match the constraint.`

The `composer.json` requires `"bugsnag/bugsnag-symfony": "dev-symfony-4-fixes"` but this version doesn’t seem to exist, so BugSnag can’t be installed.

## Changeset
`composer.json`:

`"bugsnag/bugsnag-symfony": "dev-symfony-4-fixes"`
Is now
`"bugsnag/bugsnag-symfony": "^1.5.0"`

This matches the `symfony50` example.

## Testing
Was finally able to run `composer install`.
All test events were successfully reported to the BugSnag dashboard.

### Jira
https://smartbear.atlassian.net/browse/SUP-3061