### PR TITLE
feat: add support for symfony 7

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(self::ROOT_NAME);
         $rootNode = $this->getRootNode($treeBuilder);

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "require": {
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.29.0",
-        "symfony/config": "^2.7|^3|^4|^5|^6",
-        "symfony/console": "^2.7|^3|^4|^5|^6",
-        "symfony/dependency-injection": "^2.7|^3|^4|^5|^6",
-        "symfony/http-foundation": "^2.7|^3|^4|^5|^6",
-        "symfony/http-kernel": "^2.7|^3|^4|^5|^6",
-        "symfony/security-core": "^2.7|^3|^4|^5|^6"
+        "symfony/config": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/console": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/dependency-injection": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/http-foundation": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/http-kernel": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/security-core": "^2.7|^3|^4|^5|^6|^7"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",


### PR DESCRIPTION
## Goal

Support this bundle in symfony 7 projects.

## Changeset

Allow symfony 7 in dependencies
Type `getConfigTreeBuilder` function (needed for syfmony 7)

## Testing

run tests