### PR TITLE
Update compatibility for Symfony 7

### DIFF
--- a/.ci/require-symfony.sh
+++ b/.ci/require-symfony.sh
@@ -51,6 +51,6 @@ else
     # Symfony Messenger only exists from 4.1.0 onward
     case "$SYMFONY_VERSION" in
         4.0*) ;;
-        ^[4-6]*) composer require "symfony/messenger:${SYMFONY_VERSION}" --no-update ;;
+        ^[4-7]*) composer require "symfony/messenger:${SYMFONY_VERSION}" --no-update ;;
     esac
 fi

--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -7,7 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        symfony-version: ['^3.4', '^4.4', '^5.0', '^6.0']
+        include:
+            - php-version: '8.0'
+              symfony-version: '^3.4'
+            - php-version: '8.0'
+              symfony-version: '^4.4'
+            - php-version: '8.0'
+              symfony-version: '^5.0'
+            - php-version: '8.0'
+              symfony-version: '^6.0'
+            - php-version: '8.2'
+              symfony-version: '^7.0'
 
     steps:
     - uses: actions/checkout@v2
@@ -15,7 +25,7 @@ jobs:
     - name: install PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
+        php-version: ${{ matrix.php-version }}
 
     - name: Fetch decisions.yml
       run: curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o decisions.yml

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -17,6 +17,8 @@ jobs:
         include:
           - php-version: '7.2'
             symfony-version: 2
+          - php-version: '8.2'
+            symfony-version: 7
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -13,21 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-version: '5.5.9'
-            symfony-version: '2.7.*'
-            composer-flags: '--prefer-lowest'
-          - php-version: '5.5'
-            symfony-version: '2.7.*'
-          - php-version: '5.5'
-            symfony-version: '2.8.*'
-          - php-version: '5.5'
-            symfony-version: '^3.0'
-          - php-version: '5.6'
-            symfony-version: '2.7.*'
-          - php-version: '5.6'
-            symfony-version: '2.8.*'
-          - php-version: '5.6'
-            symfony-version: '^3.0'
           - php-version: '7.0'
             symfony-version: '2.8.*'
           - php-version: '7.0'

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -87,6 +87,8 @@ jobs:
           - php-version: '8.2'
             symfony-version: '^6.0'
           - php-version: '8.2'
+            symfony-version: '^7.0'
+          - php-version: '8.2'
             symfony-version: 'latest'
 
     steps:

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(self::ROOT_NAME);
         $rootNode = $this->getRootNode($treeBuilder);

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.0",
         "bugsnag/bugsnag": "^3.29.0",
         "symfony/config": "^2.7|^3|^4|^5|^6|^7",
         "symfony/console": "^2.7|^3|^4|^5|^6|^7",

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "require": {
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.29.0",
-        "symfony/config": "^2.7|^3|^4|^5|^6",
-        "symfony/console": "^2.7|^3|^4|^5|^6",
-        "symfony/dependency-injection": "^2.7|^3|^4|^5|^6",
-        "symfony/http-foundation": "^2.7|^3|^4|^5|^6",
-        "symfony/http-kernel": "^2.7|^3|^4|^5|^6",
-        "symfony/security-core": "^2.7|^3|^4|^5|^6"
+        "symfony/config": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/console": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/dependency-injection": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/http-foundation": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/http-kernel": "^2.7|^3|^4|^5|^6|^7",
+        "symfony/security-core": "^2.7|^3|^4|^5|^6|^7"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",


### PR DESCRIPTION
## Goal

Make the package compatible with Symfony 7.

## Design

Because Symfony 7 compatibility requires return type-hinting because the framework types everything, we need to drop support for PHP < 7.0.

## Changeset

Allowed versions 7 of symfony packages called in composer.json and update CI configuration.

## Testing

Ran phpunit bin and checked if tests failed or not, they didn't.