### PR TITLE
Release v1.14.1

### DIFF
--- a/BugsnagBundle.php
+++ b/BugsnagBundle.php
@@ -11,5 +11,5 @@ class BugsnagBundle extends Bundle
      *
      * @return string
      */
-    const VERSION = '1.14.0';
+    const VERSION = '1.14.1';
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 1.14.1 (2024-01-23)
+
+* Fix "Configuration class not found" error when using Composer's `--classmap-authoritative` option
+  [#174](https://github.com/bugsnag/bugsnag-symfony/pull/174)
+
 ## 1.14.0 (2024-01-16)
 
 * Add support for Symfony 7

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Bugsnag\BugsnagBundle\DependencyInjection;
-
-if (PHP_MAJOR_VERSION >= 7) {
-    require_once __DIR__.'/configuration-with-return-type.php';
-} else {
-    require_once __DIR__.'/configuration-without-return-type.php';
-}

--- a/DependencyInjection/ConfigurationWithReturnType.php
+++ b/DependencyInjection/ConfigurationWithReturnType.php
@@ -4,9 +4,9 @@
  * This file declares a Configuration class with a return type on the
  * 'getConfigTreeBuilder' for compatibility with Symfony 7+
  *
- * This is required to be in a separate file with Configuration.php requiring it
- * at runtime so that we can maintain compatibility with PHP 5, where return
- * types are not supported
+ * This is required to be in a separate file with
+ * 'create-configuration-class-alias.php' requiring it at runtime so that we can
+ * maintain compatibility with PHP 5 where return types are not supported
  */
 
 namespace Bugsnag\BugsnagBundle\DependencyInjection;
@@ -14,7 +14,7 @@ namespace Bugsnag\BugsnagBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration extends BaseConfiguration implements ConfigurationInterface
+class ConfigurationWithReturnType extends BaseConfiguration implements ConfigurationInterface
 {
     /**
      * Get the configuration tree builder.

--- a/DependencyInjection/ConfigurationWithoutReturnType.php
+++ b/DependencyInjection/ConfigurationWithoutReturnType.php
@@ -6,14 +6,14 @@
  * not supported
  *
  * Symfony 7 requires a return type on this method, which is implemented in
- * 'configuration-with-return-type.php' and required in 'Configuration.php' when
- * running on PHP 7+
+ * 'ConfigurationWithReturnType.php' and is used by
+ * 'create-configuration-class-alias.php' when running on PHP 7+
  */
 
 namespace Bugsnag\BugsnagBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration extends BaseConfiguration implements ConfigurationInterface
+class ConfigurationWithoutReturnType extends BaseConfiguration implements ConfigurationInterface
 {
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "autoload": {
         "psr-4": {
             "Bugsnag\\BugsnagBundle\\": ""
-        }
+        },
+        "files": ["create-configuration-class-alias.php"]
     },
     "extra": {
         "branch-alias": {

--- a/create-configuration-class-alias.php
+++ b/create-configuration-class-alias.php
@@ -1,0 +1,7 @@
+<?php
+
+$class = PHP_MAJOR_VERSION >= 7
+    ? \Bugsnag\BugsnagBundle\DependencyInjection\ConfigurationWithReturnType::class
+    : \Bugsnag\BugsnagBundle\DependencyInjection\ConfigurationWithoutReturnType::class;
+
+class_alias($class, \Bugsnag\BugsnagBundle\DependencyInjection\Configuration::class);

--- a/features/fixtures/symfony-7/.env
+++ b/features/fixtures/symfony-7/.env
@@ -15,7 +15,7 @@
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
+APP_ENV=prod
 APP_SECRET=86da11dd44c7d9586497e12ee145efb9
 ###< symfony/framework-bundle ###
 

--- a/features/fixtures/symfony-7/Dockerfile
+++ b/features/fixtures/symfony-7/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer
 
 RUN sh setup-github-token.sh
 RUN php setup-bugsnag-config.php
-RUN composer install
+RUN composer install --no-dev --classmap-authoritative
+RUN php bin/console cache:clear
 
 CMD ["php", "-S", "0.0.0.0:8000", "-t", "public"]

--- a/features/ooms.feature
+++ b/features/ooms.feature
@@ -19,6 +19,7 @@ Scenario: OOM from a single large allocation
 
 @not_symfony_2
 @not_symfony_4
+@not_symfony_7
 Scenario: OOM from many small allocations
   # Symfony does a lot more stuff in debug mode, which can cause it to run OOM
   # again when trying to handle the original OOM


### PR DESCRIPTION
* Fix "Configuration class not found" error when using Composer's `--classmap-authoritative` option
  [#174](https://github.com/bugsnag/bugsnag-symfony/pull/174)
