### PR TITLE
Remove CSS & JS blocks from base template in Symfony 7 Maze Runner fixture

### DIFF
--- a/features/fixtures/symfony-7/templates/base.html.twig
+++ b/features/fixtures/symfony-7/templates/base.html.twig
@@ -4,12 +4,6 @@
         <meta charset="UTF-8">
         <title>{% block title %}Welcome!{% endblock %}</title>
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text></svg>">
-        {% block stylesheets %}
-        {% endblock %}
-
-        {% block javascripts %}
-{% block importmap %}{{ importmap('app') }}{% endblock %}
-        {% endblock %}
     </head>
     <body>
         {% block body %}{% endblock %}


### PR DESCRIPTION
## Goal

We don't need these and the importmap block is causing Twig to throw a syntax error:

> Twig\Error\SyntaxError: The block 'importmap' has already been defined line 11.

It's unclear exactly what changed to cause this as I couldn't find any of the installed packages that had a release when it started, but it's unrelated to this package