### PR TITLE
Prevent duplicate class declaration warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Prevent duplicate `Configuration` class declaration warnings
+  [#178](https://github.com/bugsnag/bugsnag-symfony/pull/178)
+
 ## 1.14.1 (2024-01-23)
 
 * Fix "Configuration class not found" error when using Composer's `--classmap-authoritative` option

--- a/create-configuration-class-alias.php
+++ b/create-configuration-class-alias.php
@@ -1,7 +1,11 @@
 <?php
 
-$class = PHP_MAJOR_VERSION >= 7
-    ? \Bugsnag\BugsnagBundle\DependencyInjection\ConfigurationWithReturnType::class
-    : \Bugsnag\BugsnagBundle\DependencyInjection\ConfigurationWithoutReturnType::class;
+// protect against this file being required multiple times, leading to duplicate
+// class declaration warnings
+if (!class_exists(\Bugsnag\BugsnagBundle\DependencyInjection\Configuration::class, false)) {
+    $class = PHP_MAJOR_VERSION >= 7
+        ? \Bugsnag\BugsnagBundle\DependencyInjection\ConfigurationWithReturnType::class
+        : \Bugsnag\BugsnagBundle\DependencyInjection\ConfigurationWithoutReturnType::class;
 
-class_alias($class, \Bugsnag\BugsnagBundle\DependencyInjection\Configuration::class);
+    class_alias($class, \Bugsnag\BugsnagBundle\DependencyInjection\Configuration::class);
+}


### PR DESCRIPTION
## Goal

We've had a report of a duplicate class declaration warning coming from the `create-configuration-class-alias.php` file. I was unable to reproduce the issue but we can wrap the declaration in a `class_exists` check to ensure we only ever declare the class once