### PR TITLE
Add PHP 8.4 to testing matrix

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -19,6 +19,8 @@ jobs:
             symfony-version: 2
           - php-version: '8.3'
             symfony-version: 7
+          - php-version: '8.4'
+            symfony-version: 7
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -98,6 +98,10 @@ jobs:
             symfony-version: '^7.0'
           - php-version: '8.3'
             symfony-version: 'latest'
+          - php-version: '8.4'
+            symfony-version: '^7.0'
+          - php-version: '8.4'
+            symfony-version: 'latest'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Goal

Ensures we have compatibility with PHP 8.4, with no deprecation warnings.