### PR TITLE
feat(symfony): Add support for Symfony 8

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -103,6 +103,8 @@ jobs:
           - php-version: '8.4'
             symfony-version: '^7.0'
           - php-version: '8.4'
+            symfony-version: '^8.0'
+          - php-version: '8.4'
             symfony-version: 'latest'
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## Unreleased
+
+### Enhancements
+
+* Add support for Symfony 8
+
 ## v1.14.3 (2025-01-30)
 
 This release should ensure compatibility with PHP 8.4 by removing the usage of certain

--- a/DependencyInjection/BugsnagExtension.php
+++ b/DependencyInjection/BugsnagExtension.php
@@ -17,7 +17,7 @@ class BugsnagExtension extends Extension
      *
      * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 

--- a/DependencyInjection/BugsnagExtension.php
+++ b/DependencyInjection/BugsnagExtension.php
@@ -5,7 +5,7 @@ namespace Bugsnag\BugsnagBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class BugsnagExtension extends Extension
 {

--- a/EventListener/BugsnagListener.php
+++ b/EventListener/BugsnagListener.php
@@ -265,7 +265,7 @@ class BugsnagListener implements EventSubscriberInterface
     /**
      * @return array<string, array{string, int}>
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         $listeners = [
             KernelEvents::REQUEST => ['onKernelRequest', 256],

--- a/EventListener/BugsnagShutdown.php
+++ b/EventListener/BugsnagShutdown.php
@@ -32,7 +32,7 @@ class BugsnagShutdown implements EventSubscriberInterface, ShutdownStrategyInter
      *
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         $listeners = [
             KernelEvents::TERMINATE => ['onTerminate', 10],

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "require": {
         "php": ">=5.5",
         "bugsnag/bugsnag": "^3.29.0",
-        "symfony/config": "^2.7|^3|^4|^5|^6|^7",
-        "symfony/console": "^2.7|^3|^4|^5|^6|^7",
-        "symfony/dependency-injection": "^2.7|^3|^4|^5|^6|^7",
-        "symfony/http-foundation": "^2.7|^3|^4|^5|^6|^7",
-        "symfony/http-kernel": "^2.7|^3|^4|^5|^6|^7",
-        "symfony/security-core": "^2.7|^3|^4|^5|^6|^7"
+        "symfony/config": "^2.7|^3|^4|^5|^6|^7|^8",
+        "symfony/console": "^2.7|^3|^4|^5|^6|^7|^8",
+        "symfony/dependency-injection": "^2.7|^3|^4|^5|^6|^7|^8",
+        "symfony/http-foundation": "^2.7|^3|^4|^5|^6|^7|^8",
+        "symfony/http-kernel": "^2.7|^3|^4|^5|^6|^7|^8",
+        "symfony/security-core": "^2.7|^3|^4|^5|^6|^7|^8"
     },
     "require-dev": {
         "graham-campbell/testbench-core": "^1.1",


### PR DESCRIPTION
## Goal

Symfony 8 has been released, this PR allow installing the bundle on it.

## Changeset

- Added Symfony 8
- Fixed deprecation and errors (#186 as well)

## Testing

`make` is green. I suspect old versions are not going to like the typehint.